### PR TITLE
Modification to JGTModel doProcess variable

### DIFF
--- a/jgrassgears/src/main/java/org/jgrasstools/gears/libs/modules/JGTModel.java
+++ b/jgrassgears/src/main/java/org/jgrasstools/gears/libs/modules/JGTModel.java
@@ -34,6 +34,7 @@ import oms3.annotations.Execute;
 import oms3.annotations.Finalize;
 import oms3.annotations.In;
 import oms3.annotations.Initialize;
+import oms3.annotations.Out;
 import oms3.annotations.UI;
 
 import org.geotools.coverage.grid.GridCoverage2D;
@@ -132,6 +133,8 @@ public class JGTModel implements Process {
      */
     // TODO check this out???? @Out
     @UI(JGTConstants.ITERATOR_UI_HINT)
+    @In
+    @Out
     public boolean doProcess = false;
 
     /**


### PR DESCRIPTION
It was necessary to use the OmsTimeSrieIteratorReader in OMS, since OMS was not
able to recognize the doProcess variable  as a field.