### PR TITLE
multiple code improvements: squid:S1118, squid:CommentedOutCodeLine, squid:S2293, squid:S2259

### DIFF
--- a/grass/src/main/java/org/jgrasstools/grass/GrassCodeGenerator.java
+++ b/grass/src/main/java/org/jgrasstools/grass/GrassCodeGenerator.java
@@ -36,15 +36,11 @@ import org.jgrasstools.grass.utils.Oms3CodeWrapper;
  */
 public class GrassCodeGenerator {
 
+    private GrassCodeGenerator() {}
+
     @SuppressWarnings("nls")
     public static void main( String[] args ) throws Exception {
 
-        // File generationFolder = new
-        // File("D:\\development\\jgrasstools-hg\\jgrasstools\\grass\\src\\main\\java\\");
-        // String gisbase = "C:\\OSGeo4W\\apps\\grass\\grass-6.4.1\\";
-        // String shell = "C:\\OSGeo4W\\apps\\msys\\bin\\sh.exe";
-
-        // LINUX
         File generationFolder = new File("/home/moovida/development/jgrasstools-hg/jgrasstools/grass/src/main/java/");
         String gisbase = "/usr/lib/grass64";
         String shell = "/bin/sh";
@@ -62,7 +58,7 @@ public class GrassCodeGenerator {
 
         String mapsetForRun = GrassUtils.prepareMapsetForRun(false);
 
-        List<File> allFiles = new ArrayList<File>();
+        List<File> allFiles = new ArrayList<>();
         File[] binFiles = binFolder.listFiles();
         List<File> binsList = Arrays.asList(binFiles);
         allFiles.addAll(binsList);
@@ -90,12 +86,6 @@ public class GrassCodeGenerator {
             }
 
             System.out.println("Generating class: " + binName);
-            // if (GrassUtils.incompatibleGrassModules.contains(binName)) {
-            // continue;
-            // }
-            // if (!binName.equals("r.cats")) {
-            // continue;
-            // }
 
             GrassModuleRunnerWithScript grassRunner = new GrassModuleRunnerWithScript(null, null);
             String result = grassRunner.runModule(new String[]{binFile.getAbsolutePath(), "--interface-description"},
@@ -130,7 +120,9 @@ public class GrassCodeGenerator {
                 classWriter = new BufferedWriter(new FileWriter(moduleFile));
                 classWriter.write(oms3Class);
             } finally {
-                classWriter.close();
+                if(classWriter != null ) {
+                    classWriter.close();
+                }
             }
         }
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S1118 Utility classes should not have public constructors.
squid:CommentedOutCodeLine Sections of code should not be "commented out".
squid:S2293 The diamond operator ("<>") should be used.
squid:S2259 Null pointers should not be dereferenced.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS1118
https://dev.eclipse.org/sonar/coding_rules#q=squid%3ACommentedOutCodeLine
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS2293
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS2259
Please let me know if you have any questions.
George Kankava