### PR TITLE
squid:S2293 The diamond operator ("<>") should be used

### DIFF
--- a/grass/src/main/java/org/jgrasstools/grass/dtd64/GrassInterface.java
+++ b/grass/src/main/java/org/jgrasstools/grass/dtd64/GrassInterface.java
@@ -110,7 +110,7 @@ public class GrassInterface {
      */
     public List<Task> getTask() {
         if (task == null) {
-            task = new ArrayList<Task>();
+            task = new ArrayList<>();
         }
         return this.task;
     }

--- a/grass/src/main/java/org/jgrasstools/grass/dtd64/Keydesc.java
+++ b/grass/src/main/java/org/jgrasstools/grass/dtd64/Keydesc.java
@@ -54,7 +54,7 @@ public class Keydesc {
      */
     public List<Item> getItem() {
         if (item == null) {
-            item = new ArrayList<Item>();
+            item = new ArrayList<>();
         }
         return this.item;
     }

--- a/grass/src/main/java/org/jgrasstools/grass/dtd64/ParameterGroup.java
+++ b/grass/src/main/java/org/jgrasstools/grass/dtd64/ParameterGroup.java
@@ -110,7 +110,7 @@ public class ParameterGroup {
      */
     public List<Parameter> getParameter() {
         if (parameter == null) {
-            parameter = new ArrayList<Parameter>();
+            parameter = new ArrayList<>();
         }
         return this.parameter;
     }
@@ -139,7 +139,7 @@ public class ParameterGroup {
      */
     public List<Flag> getFlag() {
         if (flag == null) {
-            flag = new ArrayList<Flag>();
+            flag = new ArrayList<>();
         }
         return this.flag;
     }

--- a/grass/src/main/java/org/jgrasstools/grass/dtd64/Task.java
+++ b/grass/src/main/java/org/jgrasstools/grass/dtd64/Task.java
@@ -140,7 +140,7 @@ public class Task {
      */
     public List<Parameter> getParameter() {
         if (parameter == null) {
-            parameter = new ArrayList<Parameter>();
+            parameter = new ArrayList<>();
         }
         return this.parameter;
     }
@@ -169,7 +169,7 @@ public class Task {
      */
     public List<Flag> getFlag() {
         if (flag == null) {
-            flag = new ArrayList<Flag>();
+            flag = new ArrayList<>();
         }
         return this.flag;
     }
@@ -198,7 +198,7 @@ public class Task {
      */
     public List<ParameterGroup> getParameterGroup() {
         if (parameterGroup == null) {
-            parameterGroup = new ArrayList<ParameterGroup>();
+            parameterGroup = new ArrayList<>();
         }
         return this.parameterGroup;
     }

--- a/grass/src/main/java/org/jgrasstools/grass/dtd64/Values.java
+++ b/grass/src/main/java/org/jgrasstools/grass/dtd64/Values.java
@@ -54,7 +54,7 @@ public class Values {
      */
     public List<Value> getValue() {
         if (value == null) {
-            value = new ArrayList<Value>();
+            value = new ArrayList<>();
         }
         return this.value;
     }


### PR DESCRIPTION
This pull request is focused on resolving occurrence of Sonar rule
squid:S2293 The diamond operator ("<>") should be used.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS2293
Please let me know if you have any questions.
George Kankava