### PR TITLE
multiple code improvements: squid:S1854, squid:S2386, squid:S1118, squid:S1192, squid:S1481, squid:CommentedOutCodeLine, squid:UselessParenthesesCheck, squid:S1488, squid:S00117

### DIFF
--- a/grass/src/main/java/org/jgrasstools/grass/utils/GrassUtils.java
+++ b/grass/src/main/java/org/jgrasstools/grass/utils/GrassUtils.java
@@ -164,7 +164,7 @@ public class GrassUtils {
     /**
      * Modules that can't be launched in non-interactive mode or simply do not make sense.
      */
-    public static final List<String> incompatibleGrassModules = Arrays.asList("v.build.polylines", "v.build", "v.category",
+    protected static final List<String> incompatibleGrassModules = Arrays.asList("v.build.polylines", "v.build", "v.category",
             "v.convert", "v.db.connect", "v.digit", "v.in.db", "v.in.sites", "v.kernel", "v.label.sa", "v.label", "v.lrs.create",
             "v.lrs.label", "v.lrs.segment", "v.lrs.where", "v.proj", "v.support", "v.to.rast3", "v.what", "v.what.rast",
             "r.compress", "r.random.surface", "r.region", "r.support", "r.support.stats", "r.timestamp", "r.to.rast3",
@@ -177,7 +177,7 @@ public class GrassUtils {
             "v.db.univar", "v.db.update", "v.in.e00", "v.in.sites.all", "v.univar.sh", "r.external", "v.external", "v.colors",
             "v.in.garmin", "v.in.gpsbabel", "v.out.gpsbabel", "r.proj", "v.proj", "r.category");
 
-    public static final List<String> reservedWords = Arrays
+    protected static final List<String> reservedWords = Arrays
             .asList("abstract", "assert", "boolean", "break", "byte", "case", "catch", "char", "class", "const", "continue",
                     "default", "double", "do", "else", "enum", "extends", "false", "final", "finally", "float", "for", "goto",
                     "if", "implements", "import", "instanceof", "int", "interface", "long", "native", "new", "null", "package",
@@ -194,6 +194,14 @@ public class GrassUtils {
     public static final String BASEPACKAGE = "org.osgeo.grass.";
 
     /**
+     * String Constants
+     */
+    private static final String PERMANENT = "PERMANENT";
+    private static final String OS_NAME = "os.name";
+
+    private GrassUtils() {}
+
+    /**
      * Get the jaxb grass {@link Task} for a given xml string.
      * 
      * @param grassXml te xml string to parse.
@@ -201,25 +209,23 @@ public class GrassUtils {
      * @throws Exception
      */
     public static Task getTask( String grassXml ) throws Exception {
-        String FEATURE_NAMESPACES = "http://xml.org/sax/features/namespaces";
-        String FEATURE_NAMESPACE_PREFIXES = "http://xml.org/sax/features/namespace-prefixes";
+        String featureNamespaces = "http://xml.org/sax/features/namespaces";
+        String featureNamespacePrefixes = "http://xml.org/sax/features/namespace-prefixes";
         JAXBContext jaxbContext = JAXBContext.newInstance(GrassInterface.class);
 
         XMLReader xmlreader = XMLReaderFactory.createXMLReader();
-        xmlreader.setFeature(FEATURE_NAMESPACES, true);
-        xmlreader.setFeature(FEATURE_NAMESPACE_PREFIXES, true);
+        xmlreader.setFeature(featureNamespaces, true);
+        xmlreader.setFeature(featureNamespacePrefixes, true);
         xmlreader.setEntityResolver(new EntityResolver(){
             public InputSource resolveEntity( String publicId, String systemId ) throws SAXException, IOException {
-                InputSource inputSource = new InputSource(GrassInterface.class.getResourceAsStream("/grass-interface.dtd"));
-                return inputSource;
+                return new InputSource(GrassInterface.class.getResourceAsStream("/grass-interface.dtd"));
             }
         });
 
         InputSource input = new InputSource(new StringReader(grassXml));
         Source source = new SAXSource(xmlreader, input);
         Unmarshaller unmarshaller = jaxbContext.createUnmarshaller();
-        Task grassInterface = (Task) unmarshaller.unmarshal(source);
-        return grassInterface;
+        return (Task) unmarshaller.unmarshal(source);
     }
 
     /**
@@ -302,7 +308,7 @@ public class GrassUtils {
             }
             out.close();
         } catch (final IOException e) {
-            throw (e);
+            throw e;
         }
     }
 
@@ -357,14 +363,14 @@ public class GrassUtils {
 
         // FIXME add folder creation checks
         final String tmpFolder = new String(mapsetFolder.substring(0, mapsetFolder.lastIndexOf(File.separator)));
-        final boolean b = new File(tmpFolder).mkdir();
-        new File(tmpFolder + File.separator + "PERMANENT").mkdir();
+        new File(tmpFolder).mkdir();
+        new File(tmpFolder + File.separator + PERMANENT).mkdir();
         new File(tmpFolder + File.separator + "user").mkdir();
-        new File(tmpFolder + File.separator + "PERMANENT" + File.separator + ".tmp").mkdir();
-        writeGRASSWindow(tmpFolder + File.separator + "PERMANENT" + File.separator + "DEFAULT_WIND", isLatLon);
-        new File(tmpFolder + File.separator + "PERMANENT" + File.separator + "MYNAME").createNewFile();
+        new File(tmpFolder + File.separator + PERMANENT + File.separator + ".tmp").mkdir();
+        writeGRASSWindow(tmpFolder + File.separator + PERMANENT + File.separator + "DEFAULT_WIND", isLatLon);
+        new File(tmpFolder + File.separator + PERMANENT + File.separator + "MYNAME").createNewFile();
         try {
-            final FileWriter fstream = new FileWriter(tmpFolder + File.separator + "PERMANENT" + File.separator + "MYNAME");
+            final FileWriter fstream = new FileWriter(tmpFolder + File.separator + PERMANENT + File.separator + "MYNAME");
             final BufferedWriter out = new BufferedWriter(fstream);
             if (!isLatLon) {
                 /* XY location */
@@ -375,23 +381,23 @@ public class GrassUtils {
             }
             out.close();
         } catch (final IOException e) {
-            throw (e);
+            throw e;
         }
         if (isLatLon) {
-            new File(tmpFolder + File.separator + "PERMANENT" + File.separator + "PROJ_INFO").createNewFile();
+            new File(tmpFolder + File.separator + PERMANENT + File.separator + "PROJ_INFO").createNewFile();
             try {
-                final FileWriter fstream = new FileWriter(tmpFolder + File.separator + "PERMANENT" + File.separator + "PROJ_INFO");
+                final FileWriter fstream = new FileWriter(tmpFolder + File.separator + PERMANENT + File.separator + "PROJ_INFO");
                 final BufferedWriter out = new BufferedWriter(fstream);
                 out.write("name: Latitude-Longitude\n");
                 out.write("proj: ll\n");
                 out.write("ellps: wgs84\n");
                 out.close();
             } catch (final IOException e) {
-                throw (e);
+                throw e;
             }
-            new File(tmpFolder + File.separator + "PERMANENT" + File.separator + "PROJ_UNITS").createNewFile();
+            new File(tmpFolder + File.separator + PERMANENT + File.separator + "PROJ_UNITS").createNewFile();
             try {
-                final FileWriter fstream = new FileWriter(tmpFolder + File.separator + "PERMANENT" + File.separator
+                final FileWriter fstream = new FileWriter(tmpFolder + File.separator + PERMANENT + File.separator
                         + "PROJ_UNITS");
                 final BufferedWriter out = new BufferedWriter(fstream);
                 out.write("unit: degree\n");
@@ -399,10 +405,10 @@ public class GrassUtils {
                 out.write("meters: 1.0\n");
                 out.close();
             } catch (final IOException e) {
-                throw (e);
+                throw e;
             }
         }
-        writeGRASSWindow(tmpFolder + File.separator + "PERMANENT" + File.separator + "WIND", isLatLon);
+        writeGRASSWindow(tmpFolder + File.separator + PERMANENT + File.separator + "WIND", isLatLon);
         new File(tmpFolder + File.separator + "user" + File.separator + "dbf").mkdir();
         new File(tmpFolder + File.separator + "user" + File.separator + ".tmp").mkdir();
         new File(tmpFolder + File.separator + "user" + File.separator + "VAR").createNewFile();
@@ -413,7 +419,7 @@ public class GrassUtils {
             out.write("DB_DATABASE: $GISDBASE/$LOCATION_NAME/$MAPSET/dbf/\n");
             out.close();
         } catch (final IOException e) {
-            throw (e);
+            throw e;
         }
         writeGRASSWindow(tmpFolder + File.separator + "user" + File.separator + "WIND", isLatLon);
     }
@@ -432,7 +438,7 @@ public class GrassUtils {
                 }
             }
         }
-        return (path.delete());
+        return path.delete();
     }
 
     /**
@@ -453,8 +459,8 @@ public class GrassUtils {
      * @return "true", if we are running on Windows, "false" otherwise.
      */
     public static boolean isWindows() {
-        final String os = System.getProperty("os.name").toLowerCase();
-        return (os.indexOf("win") >= 0);
+        final String os = System.getProperty(OS_NAME).toLowerCase();
+        return os.indexOf("win") >= 0;
     }
 
     /**
@@ -463,8 +469,8 @@ public class GrassUtils {
      * @return "true", if we are running on Mac OS X, "false" otherwise.
      */
     public static boolean isMacOSX() {
-        final String os = System.getProperty("os.name").toLowerCase();
-        return (os.indexOf("mac") >= 0);
+        final String os = System.getProperty(OS_NAME).toLowerCase();
+        return os.indexOf("mac") >= 0;
     }
 
     /**
@@ -473,8 +479,8 @@ public class GrassUtils {
      * @return "true", if we are running on Unix/Linux, "false" otherwise.
      */
     public static boolean isUnix() {
-        final String os = System.getProperty("os.name").toLowerCase();
-        return ((os.indexOf("nix") >= 0) || (os.indexOf("nux") >= 0));
+        final String os = System.getProperty(OS_NAME).toLowerCase();
+        return (os.indexOf("nix") >= 0) || (os.indexOf("nux") >= 0);
     }
 
     /**
@@ -511,8 +517,6 @@ public class GrassUtils {
      */
     public static String getGuiHintsFromGisprompt( Gisprompt gisprompt ) {
         String age = gisprompt.getAge();
-        String element = gisprompt.getElement();
-        String prompt = gisprompt.getPrompt();
 
         if (age.trim().equals("old")) {
             // existing file == open file hint
@@ -524,11 +528,6 @@ public class GrassUtils {
             // mapset == open folder hint
             return FOLDERIN_UI_HINT;
         }
-        // else if (age.trim().equals("any")) {
-        // // ???
-        // return null;
-        // }
-
         return null;
     }
 
@@ -544,8 +543,7 @@ public class GrassUtils {
     public static String getModuleQualifiedStructure( String module ) {
         String[] split = module.split("\\_");
         String prefix = split[0];
-        String qualifiedName = BASEPACKAGE_PATH + prefix + "/" + module + ".java";
-        return qualifiedName;
+        return BASEPACKAGE_PATH + prefix + "/" + module + ".java";
     }
 
     /**
@@ -560,8 +558,7 @@ public class GrassUtils {
     public static String getModulePackage( String module ) {
         String[] split = module.split("\\_");
         String prefix = split[0];
-        String qualifiedName = BASEPACKAGE + prefix;
-        return qualifiedName;
+        return BASEPACKAGE + prefix;
     }
 
     /**


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S1854 - Dead stores should be removed.
squid:S2386 - Mutable fields should not be "public static".
squid:S1118 - Utility classes should not have public constructors.
squid:S1192 - String literals should not be duplicated.
squid:S1481 - Unused local variables should be removed.
squid:CommentedOutCodeLine - Sections of code should not be "commented out".
squid:UselessParenthesesCheck - Useless parentheses around expressions should be removed to prevent any misunderstanding.
squid:S1488 - Local Variables should not be declared and then immediately returned or thrown.
squid:S00117 - Local variable and method parameter names should comply with a naming convention
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS1854
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS2386
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS1118
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS1192
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS1481
https://dev.eclipse.org/sonar/coding_rules#q=squid%3ACommentedOutCodeLine
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AUselessParenthesesCheck
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS1488
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS00117
Please let me know if you have any questions.
George Kankava