### PR TITLE
multiple code improvements: squid:S2293, squid:S1149, squid:CommentedOutCodeLine, squid:S00116, squid:S1155

### DIFF
--- a/grass/src/main/java/org/jgrasstools/grass/utils/GrassModuleRunnerWithScript.java
+++ b/grass/src/main/java/org/jgrasstools/grass/utils/GrassModuleRunnerWithScript.java
@@ -32,11 +32,11 @@ import java.util.Map;
  * @author Andrea Antonello (www.hydrologis.com)
  */
 public class GrassModuleRunnerWithScript {
-    private List<GrassRunnerListener> listeners = new ArrayList<GrassRunnerListener>();
+    private List<GrassRunnerListener> listeners = new ArrayList<>();
     private final PrintStream outputStream;
     private final PrintStream errorStream;
-    private StringBuffer outSb = new StringBuffer();
-    private StringBuffer errSb = new StringBuffer();
+    private StringBuilder outSb = new StringBuilder();
+    private StringBuilder errSb = new StringBuilder();
 
     public GrassModuleRunnerWithScript( final PrintStream outputStream, final PrintStream errorStream ) {
         this.outputStream = outputStream;
@@ -115,7 +115,7 @@ public class GrassModuleRunnerWithScript {
                 } finally {
                     errorDone[0] = true;
                 }
-            };
+            }
         };
 
         outputThread.start();
@@ -160,7 +160,7 @@ public class GrassModuleRunnerWithScript {
         } else {
             outSb.append(line).append("\n");
         }
-    };
+    }
 
     private void printErr( String line ) {
         if (errorStream != null) {
@@ -168,12 +168,7 @@ public class GrassModuleRunnerWithScript {
         } else {
             errSb.append(line).append("\n");
         }
-    };
-
-    // @Override
-    // public void processfinished( String mapsetFolder ) {
-    // GrassUtils.deleteTempMapset(mapsetFolder);
-    // }
+    }
 
     public static void main( String[] args ) throws Exception {
 

--- a/grass/src/main/java/org/jgrasstools/grass/utils/Oms3CodeWrapper.java
+++ b/grass/src/main/java/org/jgrasstools/grass/utils/Oms3CodeWrapper.java
@@ -36,7 +36,7 @@ public class Oms3CodeWrapper {
 
     private StringBuilder codeBuilder = new StringBuilder();
 
-    private String INDENT = "\t";
+    private String indent = "\t";
 
     private String classSafeName;
 
@@ -89,19 +89,19 @@ public class Oms3CodeWrapper {
         codeBuilder.append("public class ").append(classSafeName).append(" {").append("\n");
         codeBuilder.append("").append("\n");
 
-        TreeSet<String> namesMap = new TreeSet<String>();
+        TreeSet<String> namesMap = new TreeSet<>();
 
         /*
          * parameters
          */
         List<Parameter> parameterList = grassTask.getParameter();
-        if (parameterList.size() > 0) {
+        if (!parameterList.isEmpty()) {
             for( Parameter parameter : parameterList ) {
                 String parameterName = parameter.getName().trim();
                 parameterName = parameterName.replaceAll("\\.", VARIABLE_DOT_SUBSTITUTION);
                 parameterName = VARIABLE_PARAMETER_PREFIX + parameterName + VARIABLE_PARAMETER_SUFFIX;
                 if (!namesMap.add(parameterName)) {
-                    System.err.println(INDENT + "Found double parameter " + parameterName + " in " + name);
+                    System.err.println(indent + "Found double parameter " + parameterName + " in " + name);
                     continue;
                 }
 
@@ -115,33 +115,18 @@ public class Oms3CodeWrapper {
                     guiHints = GrassUtils.getGuiHintsFromGisprompt(gisprompt);
 
                 if (guiHints != null)
-                    codeBuilder.append(INDENT).append("@UI(\"").append(guiHints).append("\")\n");
-                codeBuilder.append(INDENT).append("@Description(\"").append(parameterDescription);
+                    codeBuilder.append(indent).append("@UI(\"").append(guiHints).append("\")\n");
+                codeBuilder.append(indent).append("@Description(\"").append(parameterDescription);
                 if (isRequired.trim().equals("no")) {
                     codeBuilder.append(" (optional)");
                 }
                 codeBuilder.append("\")\n");
-                codeBuilder.append(INDENT).append("@In\n");
-                codeBuilder.append(INDENT).append("public String ").append(parameterName);
+                codeBuilder.append(indent).append("@In\n");
+                codeBuilder.append(indent).append("public String ").append(parameterName);
                 if (defaultValue != null) {
                     codeBuilder.append(" = \"").append(defaultValue.trim()).append("\"");
                 }
                 codeBuilder.append(";\n\n");
-
-                // String multiple = parameter.getMultiple().trim();
-                // System.out.println("\t\tMultiple: " + multiple);
-
-                // Values values = parameter.getValues();
-                // if (values != null) {
-                // System.out.println("\t\tValues:");
-                // List<Value> value = values.getValue();
-                // for( Value v : value ) {
-                // String name2 = v.getName().trim();
-                // System.out.print("\t\t\t" + name2 + " - ");
-                // String description = v.getDescription().trim();
-                // System.out.println(description);
-                // }
-                // }
             }
         }
 
@@ -154,25 +139,25 @@ public class Oms3CodeWrapper {
             flagName = flagName.replaceAll("\\.", VARIABLE_DOT_SUBSTITUTION);
             flagName = VARIABLE_FLAG_PREFIX + flagName + VARIABLE_FLAG_SUFFIX;
             if (!namesMap.add(flagName)) {
-                System.err.println(INDENT + "Found double flag " + flagName + " in " + name);
+                System.err.println(indent + "Found double flag " + flagName + " in " + name);
                 continue;
             }
 
             String descr = flag.getDescription().trim();
             descr = cleanDescription(descr);
-            codeBuilder.append(INDENT).append("@Description(\"").append(descr).append("\")\n");
-            codeBuilder.append(INDENT).append("@In\n");
-            codeBuilder.append(INDENT).append("public boolean ").append(flagName).append(" = false;\n\n");
+            codeBuilder.append(indent).append("@Description(\"").append(descr).append("\")\n");
+            codeBuilder.append(indent).append("@In\n");
+            codeBuilder.append(indent).append("public boolean ").append(flagName).append(" = false;\n\n");
         }
 
         /*
          * execution method
          */
         codeBuilder.append("\n");
-        codeBuilder.append(INDENT).append("@Execute").append("\n");
-        codeBuilder.append(INDENT).append("public void process() throws Exception {").append("\n");
-        codeBuilder.append(INDENT).append(INDENT).append("ModuleSupporter.processModule(this);").append("\n");
-        codeBuilder.append(INDENT).append("}").append("\n\n");
+        codeBuilder.append(indent).append("@Execute").append("\n");
+        codeBuilder.append(indent).append("public void process() throws Exception {").append("\n");
+        codeBuilder.append(indent).append(indent).append("ModuleSupporter.processModule(this);").append("\n");
+        codeBuilder.append(indent).append("}").append("\n\n");
 
         codeBuilder.append("}").append("\n");
     }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S2293 - The diamond operator ("<>") should be used.
squid:S1149 - Synchronized classes Vector, Hashtable, Stack and StringBuffer should not be used.
squid:CommentedOutCodeLine - Sections of code should not be "commented out".
squid:S00116 - Field names should comply with a naming convention.
squid:S1155 - Collection.isEmpty() should be used to test for emptiness.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS2293
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS1149
https://dev.eclipse.org/sonar/coding_rules#q=squid%3ACommentedOutCodeLine
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS00116
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS1155
Please let me know if you have any questions.
George Kankava