### PR TITLE
multiple code improvements: squid:S1149, squid:S1118, squid:CommentedOutCodeLine, squid:S2293, squid:S1157, squid:S1488

### DIFF
--- a/grass/src/main/java/org/jgrasstools/grass/utils/GrassRunner.java
+++ b/grass/src/main/java/org/jgrasstools/grass/utils/GrassRunner.java
@@ -32,11 +32,11 @@ import java.util.Map;
  * @author Andrea Antonello (www.hydrologis.com)
  */
 public class GrassRunner {
-    private List<GrassRunnerListener> listeners = new ArrayList<GrassRunnerListener>();
+    private List<GrassRunnerListener> listeners = new ArrayList<>();
     private final PrintStream outputStream;
     private final PrintStream errorStream;
-    private StringBuffer outSb = new StringBuffer();
-    private StringBuffer errSb = new StringBuffer();
+    private StringBuilder outSb = new StringBuilder();
+    private StringBuilder errSb = new StringBuilder();
 
     public GrassRunner( final PrintStream outputStream, final PrintStream errorStream ) {
         this.outputStream = outputStream;
@@ -65,7 +65,6 @@ public class GrassRunner {
         if (GrassUtils.isWindows()) {
             environment.put("PATH", "%PATH%;%GISBASE%/bin:%GISBASE%/scripts");
         } else {
-            // environment.put("PATH", "$PATH:$GISBASE/bin:$GISBASE/scripts");
             String path = "";
             if (environment.containsKey("Path")) {
                 path = environment.get("Path");
@@ -114,7 +113,7 @@ public class GrassRunner {
                 } finally {
                     errorDone[0] = true;
                 }
-            };
+            }
         };
 
         outputThread.start();
@@ -159,7 +158,7 @@ public class GrassRunner {
         } else {
             outSb.append(line).append("\n");
         }
-    };
+    }
 
     private void printErr( String line ) {
         if (errorStream != null) {
@@ -167,14 +166,8 @@ public class GrassRunner {
         } else {
             errSb.append(line).append("\n");
         }
-    };
+    }
 
-    // @Override
-    // public void processfinished( String mapsetFolder ) {
-    // GrassUtils.deleteTempMapset(mapsetFolder);
-    // }
-    
-    
     public static void main(String[] args) throws Exception {
 
         System.setProperty("PATH", "/home/moovida/TMP/test/");

--- a/grass/src/main/java/org/jgrasstools/grass/utils/ModuleSupporter.java
+++ b/grass/src/main/java/org/jgrasstools/grass/utils/ModuleSupporter.java
@@ -31,6 +31,8 @@ import oms3.annotations.UI;
  * @author Andrea Antonello (www.hydrologis.com)
  */
 public class ModuleSupporter {
+    private ModuleSupporter() {}
+
     public static void processModule( Object owner ) throws IOException, IllegalAccessException, Exception {
 
         String gisBase = System.getProperty(GrassUtils.GRASS_ENVIRONMENT_GISBASE_KEY);
@@ -40,13 +42,10 @@ public class ModuleSupporter {
         String className = owner.getClass().getSimpleName();
         className = className.replaceAll(GrassUtils.VARIABLE_DOT_SUBSTITUTION, ".");
         File grassCommandFile = new File(gisBase, "bin/" + className);
-        // if (!grassCommandFile.exists()) {
-        // throw new IOException("Command does not exist: " + grassCommandFile.getAbsolutePath());
-        // }
 
         GrassModuleRunnerWithScript runner = new GrassModuleRunnerWithScript(System.out, System.err);
 
-        List<String> args = new ArrayList<String>();
+        List<String> args = new ArrayList<>();
         args.add(grassCommandFile.getName());
 
         Field[] fields = owner.getClass().getFields();
@@ -161,7 +160,7 @@ public class ModuleSupporter {
         File cellFolderFile = file.getParentFile();
         File mapsetFile = cellFolderFile.getParentFile();
         File windFile = new File(mapsetFile, "WIND");
-        return cellFolderFile.getName().toLowerCase().equals("cell") && windFile.exists();
+        return cellFolderFile.getName().equalsIgnoreCase("cell") && windFile.exists();
     }
 
     public static String getLocationPath( String path ) {
@@ -174,8 +173,7 @@ public class ModuleSupporter {
     public static File getMapsetFile( String path ) {
         File file = new File(path);
         File cellFolderFile = file.getParentFile();
-        File mapsetFile = cellFolderFile.getParentFile();
-        return mapsetFile;
+        return cellFolderFile.getParentFile();
     }
 
     public static String getGrassRasterName( String path ) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S1149 - Synchronized classes Vector, Hashtable, Stack and StringBuffer should not be used.
squid:S1118 - Utility classes should not have public constructors.
squid:CommentedOutCodeLine - Sections of code should not be "commented out".
squid:S2293 - The diamond operator ("<>") should be used.
squid:S1157 - Case insensitive string comparisons should be made without intermediate upper or lower casing.
squid:S1488 - Local Variables should not be declared and then immediately returned or thrown.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS1149
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS1118
https://dev.eclipse.org/sonar/coding_rules#q=squid%3ACommentedOutCodeLine
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS2293
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS1157
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS1488
Please let me know if you have any questions.
George Kankava