### PR TITLE
multiple code improvements: squid:S1192, squid:CommentedOutCodeLine, squid:S2293, squid:ClassVariableVisibilityCheck, squid:S1213, squid:S1319, squid:S1854, squid:S2583

### DIFF
--- a/hortonmachine/src/main/java/org/jgrasstools/hortonmachine/geotools/HmProcessFactory.java
+++ b/hortonmachine/src/main/java/org/jgrasstools/hortonmachine/geotools/HmProcessFactory.java
@@ -95,7 +95,7 @@ public class HmProcessFactory implements ProcessFactory {
 
     public Map<String, Parameter< ? >> getResultInfo( Name name, Map<String, Object> parameters ) throws IllegalArgumentException {
         String moduleName = name.getLocalPart();
-        LinkedHashMap<String, List<ClassField>> modulename2fields = JGrassGears.getInstance().moduleName2Fields;
+        Map<String, List<ClassField>> modulename2fields = JGrassGears.getInstance().moduleName2Fields;
         List<ClassField> list = modulename2fields.get(moduleName);
 
         Map<String, Parameter< ? >> output = new LinkedHashMap<String, Parameter< ? >>();

--- a/hortonmachine/src/main/java/org/jgrasstools/hortonmachine/utils/WikiModulesCreator.java
+++ b/hortonmachine/src/main/java/org/jgrasstools/hortonmachine/utils/WikiModulesCreator.java
@@ -22,6 +22,7 @@ import java.io.File;
 import java.net.URL;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import oms3.annotations.Author;
@@ -61,10 +62,10 @@ public class WikiModulesCreator {
 
     public static void createModulesPages() throws Exception {
 
-        LinkedHashMap<String, List<ClassField>> hmModules = HortonMachine.getInstance().moduleName2Fields;
-        LinkedHashMap<String, List<ClassField>> jggModules = JGrassGears.getInstance().moduleName2Fields;
-        LinkedHashMap<String, Class< ? >> hmModulesClasses = HortonMachine.getInstance().moduleName2Class;
-        LinkedHashMap<String, Class< ? >> jggModulesClasses = JGrassGears.getInstance().moduleName2Class;
+        Map<String, List<ClassField>> hmModules = HortonMachine.getInstance().moduleName2Fields;
+        Map<String, List<ClassField>> jggModules = JGrassGears.getInstance().moduleName2Fields;
+        Map<String, Class< ? >> hmModulesClasses = HortonMachine.getInstance().moduleName2Class;
+        Map<String, Class< ? >> jggModulesClasses = JGrassGears.getInstance().moduleName2Class;
 
         dump(hmModules, hmModulesClasses, IMAGES_HM_BASEURL, TESTCASES_HM_BASEURL, TESTCASES_HM_BASEPACKAGE);
 
@@ -72,8 +73,8 @@ public class WikiModulesCreator {
 
     }
 
-    private static void dump( LinkedHashMap<String, List<ClassField>> modulesMap,
-            LinkedHashMap<String, Class< ? >> modulesClassesMap, String imagesBaseurl, String testcasesBaseurl,
+    private static void dump( Map<String, List<ClassField>> modulesMap,
+            Map<String, Class< ? >> modulesClassesMap, String imagesBaseurl, String testcasesBaseurl,
             String testcasesHmBasepackage ) throws Exception {
 
         Set<String> nameSet = modulesClassesMap.keySet();

--- a/hortonmachine/src/main/java/org/jgrasstools/hortonmachine/utils/WikiPageModulesOverviewCreator.java
+++ b/hortonmachine/src/main/java/org/jgrasstools/hortonmachine/utils/WikiPageModulesOverviewCreator.java
@@ -21,6 +21,7 @@ package org.jgrasstools.hortonmachine.utils;
 import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import org.jgrasstools.gears.JGrassGears;
@@ -40,10 +41,10 @@ public class WikiPageModulesOverviewCreator {
      */
     public static void createModulesOverview() {
 
-        LinkedHashMap<String, List<ClassField>> hmModules = HortonMachine.getInstance().moduleName2Fields;
-        LinkedHashMap<String, List<ClassField>> jggModules = JGrassGears.getInstance().moduleName2Fields;
-        LinkedHashMap<String, Class< ? >> hmModulesClasses = HortonMachine.getInstance().moduleName2Class;
-        LinkedHashMap<String, Class< ? >> jggModulesClasses = JGrassGears.getInstance().moduleName2Class;
+        Map<String, List<ClassField>> hmModules = HortonMachine.getInstance().moduleName2Fields;
+        Map<String, List<ClassField>> jggModules = JGrassGears.getInstance().moduleName2Fields;
+        Map<String, Class< ? >> hmModulesClasses = HortonMachine.getInstance().moduleName2Class;
+        Map<String, Class< ? >> jggModulesClasses = JGrassGears.getInstance().moduleName2Class;
 
         Set<String> hmNames = hmModules.keySet();
         String[] hmNamesArray = (String[]) hmNames.toArray(new String[hmNames.size()]);
@@ -86,8 +87,8 @@ public class WikiPageModulesOverviewCreator {
         System.out.println(sb.toString());
     }
 
-    private static void dumpModules( LinkedHashMap<String, List<ClassField>> modulesMap,
-            LinkedHashMap<String, Class< ? >> modulesClasses, String[] modulesNamesArray, StringBuilder sb, String status ) {
+    private static void dumpModules( Map<String, List<ClassField>> modulesMap,
+            Map<String, Class< ? >> modulesClasses, String[] modulesNamesArray, StringBuilder sb, String status ) {
         for( String moduleName : modulesNamesArray ) {
             List<ClassField> fieldsList = modulesMap.get(moduleName);
             if (fieldsList == null) {

--- a/jgrassgears/src/main/java/org/jgrasstools/gears/JGrassGears.java
+++ b/jgrassgears/src/main/java/org/jgrasstools/gears/JGrassGears.java
@@ -55,19 +55,60 @@ import org.scannotation.ClasspathUrlFinder;
 @SuppressWarnings("nls")
 public class JGrassGears {
 
+    /**
+     * A {@link LinkedHashMap map} of all the class names and the class itself.
+     */
+    public final Map<String, Class< ? >> moduleName2Class = new LinkedHashMap<>();
+
+    /**
+     * A {@link LinkedHashMap map} of all the class names and their fields.
+     */
+    public final Map<String, List<ClassField>> moduleName2Fields = new LinkedHashMap<>();
+
+    private static final String PUBLIC_STATIC_FINAL_STRING = "public static final String ";
+
+    private static final String QUOTATION_MARK_SEMICOLON_NEW_LINE = "\";\n";
+
     private static JGrassGears jgrassGears = null;
 
+    /**
+     * An array of all the fields used in the modules.
+     */
+    private String[] allFields;
+
+    /**
+     * An array of all the class names of the modules.
+     */
+    private String[] allClasses;
+
     private URL baseclassUrl;
+
     private JGrassGears( URL baseclassUrl ) {
         this.baseclassUrl = baseclassUrl;
     }
 
-    /**
+    public String[] getAllFields() {
+		return allFields;
+	}
+
+	public void setAllFields(String[] allFields) {
+		this.allFields = allFields;
+	}
+
+	public String[] getAllClasses() {
+		return allClasses;
+	}
+
+	public void setAllClasses(String[] allClasses) {
+		this.allClasses = allClasses;
+	}
+
+	/**
      * Retrieves the {@link JGrassGears}. If it exists, that instance is returned.
      * 
      * @return the JGrassGears annotations class.
      */
-    public synchronized static JGrassGears getInstance() {
+    public static synchronized JGrassGears getInstance() {
         if (jgrassGears == null) {
             jgrassGears = new JGrassGears(null);
             jgrassGears.gatherInformations();
@@ -94,26 +135,6 @@ public class JGrassGears {
         jgrassGears.gatherInformations();
         return jgrassGears;
     }
-
-    /**
-     * A {@link LinkedHashMap map} of all the class names and the class itself.
-     */
-    public final LinkedHashMap<String, Class< ? >> moduleName2Class = new LinkedHashMap<String, Class< ? >>();
-
-    /**
-     * A {@link LinkedHashMap map} of all the class names and their fields.
-     */
-    public final LinkedHashMap<String, List<ClassField>> moduleName2Fields = new LinkedHashMap<String, List<ClassField>>();
-
-    /**
-     * An array of all the fields used in the modules.
-     */
-    public String[] allFields = null;
-
-    /**
-     * An array of all the class names of the modules.
-     */
-    public String[] allClasses = null;
 
     private void gatherInformations() {
 
@@ -144,8 +165,8 @@ public class JGrassGears {
             /*
              * extract all classes and fields
              */
-            List<String> classNames = new ArrayList<String>();
-            List<String> fieldNamesList = new ArrayList<String>();
+            List<String> classNames = new ArrayList<>();
+            List<String> fieldNamesList = new ArrayList<>();
 
             Set<Entry<String, Class< ? >>> moduleName2ClassEntries = moduleName2Class.entrySet();
             for( Entry<String, Class< ? >> moduleName2ClassEntry : moduleName2ClassEntries ) {
@@ -156,7 +177,7 @@ public class JGrassGears {
                     System.out.println("Missing status: " + moduleClass.getCanonicalName());
                     continue;
                 }
-                String statusString = null;
+                String statusString;
                 int status = annotation.value();
                 switch( status ) {
                 case Status.CERTIFIED:
@@ -175,7 +196,7 @@ public class JGrassGears {
 
                 classNames.add(moduleName);
 
-                List<ClassField> tmpfields = new ArrayList<ClassField>();
+                List<ClassField> tmpfields = new ArrayList<>();
                 Object annotatedObject = moduleClass.newInstance();
                 ComponentAccess cA = new ComponentAccess(annotatedObject);
                 Collection<Access> inputs = cA.inputs();
@@ -251,9 +272,8 @@ public class JGrassGears {
         for( Entry<String, Class< ? >> cl : cls ) {
             System.out.println(cl.getValue().getCanonicalName());
         }
-        if(true)return;
-        LinkedHashMap<String, List<ClassField>> moduleName2Fields = jgr.moduleName2Fields;
-        LinkedHashMap<String, Class< ? >> moduleName2Class = jgr.moduleName2Class;
+        Map<String, List<ClassField>> moduleName2Fields = jgr.moduleName2Fields;
+        Map<String, Class< ? >> moduleName2Class = jgr.moduleName2Class;
 
         Set<Entry<String, List<ClassField>>> entrySet = moduleName2Fields.entrySet();
         for( Entry<String, List<ClassField>> entry : entrySet ) {
@@ -263,8 +283,8 @@ public class JGrassGears {
 
             Class< ? > moduleClass = moduleName2Class.get(moduleName);
             Description description = moduleClass.getAnnotation(Description.class);
-            sb.append("public static final String " + moduleName.toUpperCase() + "_DESCRIPTION = \"" + description.value()
-                    + "\";\n");
+            sb.append(PUBLIC_STATIC_FINAL_STRING + moduleName.toUpperCase() + "_DESCRIPTION = \"" + description.value()
+                    + QUOTATION_MARK_SEMICOLON_NEW_LINE);
             Documentation documentation = moduleClass.getAnnotation(Documentation.class);
             String doc;
             if (documentation == null) {
@@ -272,7 +292,7 @@ public class JGrassGears {
             } else {
                 doc = documentation.value();
             }
-            sb.append("public static final String " + moduleName.toUpperCase() + "_DOCUMENTATION = \"" + doc + "\";\n");
+            sb.append(PUBLIC_STATIC_FINAL_STRING + moduleName.toUpperCase() + "_DOCUMENTATION = \"" + doc + QUOTATION_MARK_SEMICOLON_NEW_LINE);
             Keywords keywords = moduleClass.getAnnotation(Keywords.class);
             String k;
             if (keywords == null) {
@@ -280,7 +300,7 @@ public class JGrassGears {
             } else {
                 k = keywords.value();
             }
-            sb.append("public static final String " + moduleName.toUpperCase() + "_KEYWORDS = \"" + k + "\";\n");
+            sb.append(PUBLIC_STATIC_FINAL_STRING + moduleName.toUpperCase() + "_KEYWORDS = \"" + k + QUOTATION_MARK_SEMICOLON_NEW_LINE);
             Label label = moduleClass.getAnnotation(Label.class);
             String lab;
             if (label == null) {
@@ -288,7 +308,7 @@ public class JGrassGears {
             } else {
                 lab = label.value();
             }
-            sb.append("public static final String " + moduleName.toUpperCase() + "_LABEL = \"" + lab + "\";\n");
+            sb.append(PUBLIC_STATIC_FINAL_STRING + moduleName.toUpperCase() + "_LABEL = \"" + lab + QUOTATION_MARK_SEMICOLON_NEW_LINE);
             Name name = moduleClass.getAnnotation(Name.class);
             String n;
             if (name == null) {
@@ -296,42 +316,21 @@ public class JGrassGears {
             } else {
                 n = name.value();
             }
-            sb.append("public static final String " + moduleName.toUpperCase() + "_NAME = \"" + n + "\";\n");
+            sb.append(PUBLIC_STATIC_FINAL_STRING + moduleName.toUpperCase() + "_NAME = \"" + n + QUOTATION_MARK_SEMICOLON_NEW_LINE);
             Status status = moduleClass.getAnnotation(Status.class);
-            // String st = "";
-            // switch( status.value() ) {
-            // case 5:
-            // st = "EXPERIMENTAL";
-            // break;
-            // case 10:
-            // st = "DRAFT";
-            // break;
-            // case 20:
-            // st = "TESTED";
-            // break;
-            // case 30:
-            // st = "VALIDATED";
-            // break;
-            // case 40:
-            // st = "CERTIFIED";
-            // break;
-            // default:
-            // st = "DRAFT";
-            // break;
-            // }
 
             sb.append("public static final int " + moduleName.toUpperCase() + "_STATUS = " + status.value() + ";\n");
             License license = moduleClass.getAnnotation(License.class);
-            sb.append("public static final String " + moduleName.toUpperCase() + "_LICENSE = \"" + license.value() + "\";\n");
+            sb.append(PUBLIC_STATIC_FINAL_STRING + moduleName.toUpperCase() + "_LICENSE = \"" + license.value() + QUOTATION_MARK_SEMICOLON_NEW_LINE);
             Author author = moduleClass.getAnnotation(Author.class);
             String authorName = author.name();
-            sb.append("public static final String " + moduleName.toUpperCase() + "_AUTHORNAMES = \"" + authorName + "\";\n");
+            sb.append(PUBLIC_STATIC_FINAL_STRING + moduleName.toUpperCase() + "_AUTHORNAMES = \"" + authorName + QUOTATION_MARK_SEMICOLON_NEW_LINE);
             String authorContact = author.contact();
-            sb.append("public static final String " + moduleName.toUpperCase() + "_AUTHORCONTACTS = \"" + authorContact + "\";\n");
+            sb.append(PUBLIC_STATIC_FINAL_STRING + moduleName.toUpperCase() + "_AUTHORCONTACTS = \"" + authorContact + QUOTATION_MARK_SEMICOLON_NEW_LINE);
 
             UI ui = moduleClass.getAnnotation(UI.class);
             if (ui != null) {
-                sb.append("public static final String " + moduleName.toUpperCase() + "_UI = \"" + ui.value() + "\";\n");
+                sb.append(PUBLIC_STATIC_FINAL_STRING + moduleName.toUpperCase() + "_UI = \"" + ui.value() + QUOTATION_MARK_SEMICOLON_NEW_LINE);
             }
 
             List<ClassField> value = entry.getValue();
@@ -342,20 +341,13 @@ public class JGrassGears {
                 }
                 String fieldDescription = classField.fieldDescription;
 
-                String str = "public static final String " + moduleName.toUpperCase() + "_" + fieldName + "_DESCRIPTION = \""
-                        + fieldDescription + "\";\n";
+                String str = PUBLIC_STATIC_FINAL_STRING + moduleName.toUpperCase() + "_" + fieldName + "_DESCRIPTION = \""
+                        + fieldDescription + QUOTATION_MARK_SEMICOLON_NEW_LINE;
                 sb.append(str);
             }
             System.out.println(sb.toString());
             System.out.println();
         }
-
-        // for( String className : jgr.allClasses ) {
-        // System.out.println(className);
-        // }
-        // for( String fieldName : jgr.allFields ) {
-        // System.out.println(fieldName);
-        // }
     }
 
 }

--- a/jgrassgears/src/main/java/org/jgrasstools/gears/geotools/GearsProcessFactory.java
+++ b/jgrassgears/src/main/java/org/jgrasstools/gears/geotools/GearsProcessFactory.java
@@ -43,7 +43,7 @@ public class GearsProcessFactory implements ProcessFactory {
 
     private static final String VERSION_STRING = "0.1-SNAPSHOT";
     private static final String namespace = "org.jgrasstools.gears";
-    private LinkedHashMap<String, Class< ? >> modulename2class;
+    private Map<String, Class< ? >> modulename2class;
 
     public Process create( Name name ) {
         String moduleName = name.getLocalPart();
@@ -78,7 +78,7 @@ public class GearsProcessFactory implements ProcessFactory {
 
     public Map<String, Parameter< ? >> getParameterInfo( Name name ) {
         String moduleName = name.getLocalPart();
-        LinkedHashMap<String, List<ClassField>> modulename2fields = JGrassGears.getInstance().moduleName2Fields;
+        Map<String, List<ClassField>> modulename2fields = JGrassGears.getInstance().moduleName2Fields;
         List<ClassField> list = modulename2fields.get(moduleName);
 
         Map<String, Parameter< ? >> input = new LinkedHashMap<String, Parameter< ? >>();
@@ -96,7 +96,7 @@ public class GearsProcessFactory implements ProcessFactory {
     public Map<String, Parameter< ? >> getResultInfo( Name name, Map<String, Object> parameters ) throws IllegalArgumentException {
 
         String moduleName = name.getLocalPart();
-        LinkedHashMap<String, List<ClassField>> modulename2fields = JGrassGears.getInstance().moduleName2Fields;
+        Map<String, List<ClassField>> modulename2fields = JGrassGears.getInstance().moduleName2Fields;
         List<ClassField> list = modulename2fields.get(moduleName);
 
         Map<String, Parameter< ? >> output = new LinkedHashMap<String, Parameter< ? >>();


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S1192 - String literals should not be duplicated.
squid:CommentedOutCodeLine - Sections of code should not be "commented out".
squid:S2293 - The diamond operator ("<>") should be used.
squid:ClassVariableVisibilityCheck - Class variable fields should not have public accessibility.
squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order.
squid:S1319 - Declarations should use Java collection interfaces such as "List" rather than specific implementation classes such as "LinkedList".
squid:S1854 - Dead stores should be removed.
squid:S2583 - Conditions should not unconditionally evaluate to "TRUE" or to "FALSE".
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1192
https://dev.eclipse.org/sonar/rules/show/squid:CommentedOutCodeLine
https://dev.eclipse.org/sonar/rules/show/squid:S2293
https://dev.eclipse.org/sonar/rules/show/squid:ClassVariableVisibilityCheck
https://dev.eclipse.org/sonar/rules/show/squid:S1213
https://dev.eclipse.org/sonar/rules/show/squid:S1319
https://dev.eclipse.org/sonar/rules/show/squid:S1854
https://dev.eclipse.org/sonar/rules/show/squid:S2583
Please let me know if you have any questions.
George Kankava