### PR TITLE
multiple code improvements: squid:S00115, squid:S1118, squid:S2147, squid:S2293, squid:S1488, squid:S1192, squid:CommentedOutCodeLine

### DIFF
--- a/grass/src/main/java/org/jgrasstools/grass/utils/GrassUtilsSextante.java
+++ b/grass/src/main/java/org/jgrasstools/grass/utils/GrassUtilsSextante.java
@@ -16,6 +16,9 @@ import java.util.UUID;
  */
 public class GrassUtilsSextante {
 
+    private static final String ELSE = "else\n";
+    private static final String JAVA_IO_TMPDIR = "java.io.tmpdir";
+
     private GrassUtilsSextante() {}
 
     /**
@@ -52,7 +55,7 @@ public class GrassUtilsSextante {
         id = UUID.randomUUID();
         tmpPrefix = new String(GrassUtils.TMP_PREFIX);
         tmpSuffix = new String("_" + id);
-        tmpBase = new String(System.getProperty("java.io.tmpdir"));
+        tmpBase = new String(System.getProperty(JAVA_IO_TMPDIR));
         if (isWindows) {
             tmpExtension = new String("bat");
         } else {
@@ -70,7 +73,7 @@ public class GrassUtilsSextante {
         id = UUID.randomUUID();
         tmpPrefix = new String(GrassUtils.TMP_PREFIX);
         tmpSuffix = new String("_" + id);
-        tmpBase = new String(System.getProperty("java.io.tmpdir"));
+        tmpBase = new String(System.getProperty(JAVA_IO_TMPDIR));
         if (tmpBase.endsWith(File.separator)) {
             tmpName = new String(tmpBase + File.separator + tmpPrefix + tmpSuffix.replace('-', '_') + ".gisrc");
         } else {
@@ -125,13 +128,13 @@ public class GrassUtilsSextante {
                 output.write("\tLCL=`echo \"$LC_ALL\" | sed 's/\\(..\\)\\(.*\\)/\\1/'`\n");
                 output.write("elif [ \"$LC_MESSAGES\" ] ; then\n");
                 output.write("\tLCL=`echo \"$LC_MESSAGES\" | sed 's/\\(..\\)\\(.*\\)/\\1/'`\n");
-                output.write("else\n");
+                output.write(ELSE);
                 output.write("\tLCL=`echo \"$LANG\" | sed 's/\\(..\\)\\(.*\\)/\\1/'`\n");
                 output.write("fi\n");
                 output.write("\n");
                 output.write("if [ -n \"$GRASS_ADDON_PATH\" ] ; then\n");
                 output.write("\tPATH=\"" + gisBase + "/bin:" + gisBase + "/scripts:$GRASS_ADDON_PATH:$PATH\"\n");
-                output.write("else\n");
+                output.write(ELSE);
                 output.write("\tPATH=\"" + gisBase + "/bin:" + gisBase + "/scripts:$PATH\"\n");
                 output.write("fi\n");
                 output.write("export PATH\n");
@@ -139,14 +142,14 @@ public class GrassUtilsSextante {
                 if (isMac) {
                     output.write("if [ ! \"$DYLD_LIBRARY_PATH\" ] ; then\n");
                     output.write("\tDYLD_LIBRARY_PATH=\"$GISBASE/lib\"\n");
-                    output.write("else\n");
+                    output.write(ELSE);
                     output.write("\tDYLD_LIBRARY_PATH=\"$GISBASE/lib:$DYLD_LIBRARY_PATH\"\n");
                     output.write("fi\n");
                     output.write("export DYLD_LIBRARY_PATH\n");
                 } else {
                     output.write("if [ ! \"$LD_LIBRARY_PATH\" ] ; then\n");
                     output.write("\tLD_LIBRARY_PATH=\"$GISBASE/lib\"\n");
-                    output.write("else\n");
+                    output.write(ELSE);
                     output.write("\tLD_LIBRARY_PATH=\"$GISBASE/lib:$LD_LIBRARY_PATH\"\n");
                     output.write("fi\n");
                     output.write("export LD_LIBRARY_PATH\n");
@@ -158,7 +161,7 @@ public class GrassUtilsSextante {
                 output.write("export GRASS_PYTHON\n");
                 output.write("if [ ! \"$PYTHONPATH\" ] ; then\n");
                 output.write("\tPYTHONPATH=\"$GISBASE/etc/python\"\n");
-                output.write("else\n");
+                output.write(ELSE);
                 output.write("\tPYTHONPATH=\"$GISBASE/etc/python:$PYTHONPATH\"\n");
                 output.write("fi\n");
                 output.write("export PYTHONPATH\n");
@@ -192,7 +195,7 @@ public class GrassUtilsSextante {
             id = UUID.randomUUID();
             tmpPrefix = new String(GrassUtils.TMP_PREFIX);
             tmpSuffix = new String("_" + id);
-            tmpBase = new String(System.getProperty("java.io.tmpdir"));
+            tmpBase = new String(System.getProperty(JAVA_IO_TMPDIR));
             if (tmpBase.endsWith(File.separator)) {
                 tmpName = new String(tmpBase + File.separator + tmpPrefix + tmpSuffix.replace('-', '_') + ".msg");
             } else {

--- a/grass/src/main/java/org/jgrasstools/grass/utils/ModuleSupporter.java
+++ b/grass/src/main/java/org/jgrasstools/grass/utils/ModuleSupporter.java
@@ -108,12 +108,6 @@ public class ModuleSupporter {
                         } else {
                             // TODO
                             throw new RuntimeException("Non grass files are not supported yet!");
-                            // String[] mapsetForRun = GrassUtils.prepareMapsetForRun(false);
-                            // GrassRunner tmpRunner = new GrassRunner(System.out, System.err);
-                            // tmpRunner.runModule(new String[]{"r.external", inPath,
-                            // inFile.getName()}, mapsetForRun[0],
-                            // mapsetForRun[1]);
-                            // mapset = mapsetForRun[0];
                         }
                     } else if (value.toLowerCase().contains("outfile")) {
                         String outPath = valueObj.toString();

--- a/grass/src/main/java/org/jgrasstools/grass/utils/Oms3CodeWrapper.java
+++ b/grass/src/main/java/org/jgrasstools/grass/utils/Oms3CodeWrapper.java
@@ -34,6 +34,10 @@ import org.jgrasstools.grass.dtd64.Task;
  */
 public class Oms3CodeWrapper {
 
+    private static final String QUOTATION_MARK_BRACKET_NEWLINE = "\")\n";
+
+    private static final String DESCRIPTION = "@Description(\"";
+
     private StringBuilder codeBuilder = new StringBuilder();
 
     private String indent = "\t";
@@ -77,7 +81,7 @@ public class Oms3CodeWrapper {
         codeBuilder.append("import oms3.annotations.Status;").append("\n");
         codeBuilder.append("").append("\n");
         if (description != null)
-            codeBuilder.append("@Description(\"").append(description.trim()).append("\")").append("\n");
+            codeBuilder.append(DESCRIPTION).append(description.trim()).append("\")").append("\n");
         codeBuilder.append("@Author(name = \"Grass Developers Community\", contact = \"http://grass.osgeo.org\")").append("\n");
         if (keyWords != null)
             codeBuilder.append("@Keywords(\"").append(keyWords.trim()).append("\")").append("\n");
@@ -115,12 +119,12 @@ public class Oms3CodeWrapper {
                     guiHints = GrassUtils.getGuiHintsFromGisprompt(gisprompt);
 
                 if (guiHints != null)
-                    codeBuilder.append(indent).append("@UI(\"").append(guiHints).append("\")\n");
-                codeBuilder.append(indent).append("@Description(\"").append(parameterDescription);
+                    codeBuilder.append(indent).append("@UI(\"").append(guiHints).append(QUOTATION_MARK_BRACKET_NEWLINE);
+                codeBuilder.append(indent).append(DESCRIPTION).append(parameterDescription);
                 if (isRequired.trim().equals("no")) {
                     codeBuilder.append(" (optional)");
                 }
-                codeBuilder.append("\")\n");
+                codeBuilder.append(QUOTATION_MARK_BRACKET_NEWLINE);
                 codeBuilder.append(indent).append("@In\n");
                 codeBuilder.append(indent).append("public String ").append(parameterName);
                 if (defaultValue != null) {
@@ -145,7 +149,7 @@ public class Oms3CodeWrapper {
 
             String descr = flag.getDescription().trim();
             descr = cleanDescription(descr);
-            codeBuilder.append(indent).append("@Description(\"").append(descr).append("\")\n");
+            codeBuilder.append(indent).append(DESCRIPTION).append(descr).append(QUOTATION_MARK_BRACKET_NEWLINE);
             codeBuilder.append(indent).append("@In\n");
             codeBuilder.append(indent).append("public boolean ").append(flagName).append(" = false;\n\n");
         }

--- a/jgrassgears/src/main/java/org/jgrasstools/gears/JGrassGears.java
+++ b/jgrassgears/src/main/java/org/jgrasstools/gears/JGrassGears.java
@@ -256,11 +256,7 @@ public class JGrassGears {
             allFields = (String[]) fieldNamesList.toArray(new String[fieldNamesList.size()]);
             Collections.sort(classNames);
             allClasses = (String[]) classNames.toArray(new String[classNames.size()]);
-        } catch (InstantiationException e) {
-            e.printStackTrace();
-        } catch (IllegalAccessException e) {
-            e.printStackTrace();
-        } catch (IOException e) {
+        } catch (InstantiationException | IllegalAccessException | IOException e) {
             e.printStackTrace();
         }
     }

--- a/jgrassgears/src/main/java/org/jgrasstools/gears/geotools/GearsProcessFactory.java
+++ b/jgrassgears/src/main/java/org/jgrasstools/gears/geotools/GearsProcessFactory.java
@@ -42,7 +42,7 @@ import org.opengis.util.InternationalString;
 public class GearsProcessFactory implements ProcessFactory {
 
     private static final String VERSION_STRING = "0.1-SNAPSHOT";
-    private static final String namespace = "org.jgrasstools.gears";
+    private static final String NAMESPACE = "org.jgrasstools.gears";
     private Map<String, Class< ? >> modulename2class;
 
     public Process create( Name name ) {
@@ -51,12 +51,9 @@ public class GearsProcessFactory implements ProcessFactory {
         try {
             Object processObj = moduleClass.newInstance();
             if (processObj instanceof Process) {
-                Process process = (Process) processObj;
-                return process;
+                return (Process) processObj;
             }
-        } catch (InstantiationException e) {
-            e.printStackTrace();
-        } catch (IllegalAccessException e) {
+        } catch (InstantiationException | IllegalAccessException e) {
             e.printStackTrace();
         }
         return null;
@@ -67,11 +64,11 @@ public class GearsProcessFactory implements ProcessFactory {
     }
 
     public Set<Name> getNames() {
-        Set<Name> names = new LinkedHashSet<Name>();
+        Set<Name> names = new LinkedHashSet<>();
         modulename2class = JGrassGears.getInstance().moduleName2Class;
         Set<String> modulesNames = modulename2class.keySet();
         for( String name : modulesNames ) {
-            names.add(new NameImpl(namespace, name));
+            names.add(new NameImpl(NAMESPACE, name));
         }
         return names;
     }
@@ -81,7 +78,7 @@ public class GearsProcessFactory implements ProcessFactory {
         Map<String, List<ClassField>> modulename2fields = JGrassGears.getInstance().moduleName2Fields;
         List<ClassField> list = modulename2fields.get(moduleName);
 
-        Map<String, Parameter< ? >> input = new LinkedHashMap<String, Parameter< ? >>();
+        Map<String, Parameter< ? >> input = new LinkedHashMap<>();
         for( ClassField classField : list ) {
             if (classField.isIn) {
                 String fieldName = classField.fieldName;
@@ -99,7 +96,7 @@ public class GearsProcessFactory implements ProcessFactory {
         Map<String, List<ClassField>> modulename2fields = JGrassGears.getInstance().moduleName2Fields;
         List<ClassField> list = modulename2fields.get(moduleName);
 
-        Map<String, Parameter< ? >> output = new LinkedHashMap<String, Parameter< ? >>();
+        Map<String, Parameter< ? >> output = new LinkedHashMap<>();
         for( ClassField classField : list ) {
             if (classField.isOut) {
                 String fieldName = classField.fieldName;

--- a/jgrassgears/src/main/java/org/jgrasstools/gears/i18n/GearsMessages.java
+++ b/jgrassgears/src/main/java/org/jgrasstools/gears/i18n/GearsMessages.java
@@ -33,25 +33,25 @@ public class GearsMessages {
     public static final int OMSHYDRO_DRAFT = 10;
     public static final int OMSHYDRO_CERTIFIED = 40;
     
-    public static final String GENERIC_pNorth_DESCRIPTION = "The north bound of the region to consider";
-    public static final String GENERIC_pSouth_DESCRIPTION = "The south bound of the region to consider";
-    public static final String GENERIC_pWest_DESCRIPTION = "The west bound of the region to consider";
-    public static final String GENERIC_pEast_DESCRIPTION = "The east bound of the region to consider";
-    public static final String GENERIC_pRows_DESCRIPTION = "The rows of the region to consider";
-    public static final String GENERIC_pCols_DESCRIPTION = "The cols of the region to consider";
-    public static final String GENERIC_pXres_DESCRIPTION = "The requested resolution in x.";
-    public static final String GENERIC_pYres_DESCRIPTION = "The requested resolution in y.";
+    public static final String GENERIC_P_NORTH_DESCRIPTION = "The north bound of the region to consider";
+    public static final String GENERIC_P_SOUTH_DESCRIPTION = "The south bound of the region to consider";
+    public static final String GENERIC_P_WEST_DESCRIPTION = "The west bound of the region to consider";
+    public static final String GENERIC_P_EAST_DESCRIPTION = "The east bound of the region to consider";
+    public static final String GENERIC_P_ROWS_DESCRIPTION = "The rows of the region to consider";
+    public static final String GENERIC_P_COLS_DESCRIPTION = "The cols of the region to consider";
+    public static final String GENERIC_P_X_RES_DESCRIPTION = "The requested resolution in x.";
+    public static final String GENERIC_P_Y_RES_DESCRIPTION = "The requested resolution in y.";
 
     public static final String OMSGEOPAPARAZZICONVERTER_LABEL = JGTConstants.VECTORPROCESSING;
     public static final String OMSGEOPAPARAZZICONVERTER_TAGS = "geopaparazzi, vector";
     public static final String OMSGEOPAPARAZZICONVERTER_NAME = "geopapconvert";
-    public static final String OMSGEOPAPARAZZICONVERTER_outData_DESCRIPTION = "The output folder";
-    public static final String OMSGEOPAPARAZZICONVERTER_doBookmarks_DESCRIPTION = "Flag to create bookmarks points";
-    public static final String OMSGEOPAPARAZZICONVERTER_doMedia_DESCRIPTION = "Flag to create media points";
-    public static final String OMSGEOPAPARAZZICONVERTER_doLogpoints_DESCRIPTION = "Flag to create log points";
-    public static final String OMSGEOPAPARAZZICONVERTER_doLoglines_DESCRIPTION = "Flag to create log lines";
-    public static final String OMSGEOPAPARAZZICONVERTER_doNotes_DESCRIPTION = "Flag to create notes";
-    public static final String OMSGEOPAPARAZZICONVERTER_inGeopaparazzi_DESCRIPTION = "The geopaparazzi folder";
+    public static final String OMSGEOPAPARAZZICONVERTER_OUTDATA_DESCRIPTION = "The output folder";
+    public static final String OMSGEOPAPARAZZICONVERTER_DO_BOOKMARKS_DESCRIPTION = "Flag to create bookmarks points";
+    public static final String OMSGEOPAPARAZZICONVERTER_DO_MEDIA_DESCRIPTION = "Flag to create media points";
+    public static final String OMSGEOPAPARAZZICONVERTER_DO_LOG_POINTS_DESCRIPTION = "Flag to create log points";
+    public static final String OMSGEOPAPARAZZICONVERTER_DO_LOG_LINES_DESCRIPTION = "Flag to create log lines";
+    public static final String OMSGEOPAPARAZZICONVERTER_DO_NOTES_DESCRIPTION = "Flag to create notes";
+    public static final String OMSGEOPAPARAZZICONVERTER_IN_GEOPAPARAZZI_DESCRIPTION = "The geopaparazzi folder";
 
     public static final String OMSLINESMOOTHERMCMASTER_DESCRIPTION = "The McMasters Sliding Averaging smoothing algorithm.";
     public static final String OMSLINESMOOTHERMCMASTER_DOCUMENTATION = "OmsLineSmootherMcMaster.html";
@@ -62,13 +62,13 @@ public class GearsMessages {
     public static final String OMSLINESMOOTHERMCMASTER_LICENSE = "General Public License Version 3 (GPLv3)";
     public static final String OMSLINESMOOTHERMCMASTER_AUTHORNAMES = "Andrea Antonello";
     public static final String OMSLINESMOOTHERMCMASTER_AUTHORCONTACTS = "http://www.hydrologis.com";
-    public static final String OMSLINESMOOTHERMCMASTER_inVector_DESCRIPTION = "The vector containing the lines to be smoothed.";
-    public static final String OMSLINESMOOTHERMCMASTER_pLookahead_DESCRIPTION = "The number of points to consider in every smoothing step (default = 7).";
-    public static final String OMSLINESMOOTHERMCMASTER_pLimit_DESCRIPTION = "Minimum length for a line to be smoothed.";
-    public static final String OMSLINESMOOTHERMCMASTER_pSlide_DESCRIPTION = "Slide parameter.";
-    public static final String OMSLINESMOOTHERMCMASTER_pDensify_DESCRIPTION = "Densifier interval.";
-    public static final String OMSLINESMOOTHERMCMASTER_pSimplify_DESCRIPTION = "Simplifier tollerance.";
-    public static final String OMSLINESMOOTHERMCMASTER_outVector_DESCRIPTION = "The vector with smoothed features.";
+    public static final String OMSLINESMOOTHERMCMASTER_IN_VECTOR_DESCRIPTION = "The vector containing the lines to be smoothed.";
+    public static final String OMSLINESMOOTHERMCMASTER_P_LOOK_AHEAD_DESCRIPTION = "The number of points to consider in every smoothing step (default = 7).";
+    public static final String OMSLINESMOOTHERMCMASTER_P_LIMIT_DESCRIPTION = "Minimum length for a line to be smoothed.";
+    public static final String OMSLINESMOOTHERMCMASTER_P_SLIDE_DESCRIPTION = "Slide parameter.";
+    public static final String OMSLINESMOOTHERMCMASTER_P_DENSIFY_DESCRIPTION = "Densifier interval.";
+    public static final String OMSLINESMOOTHERMCMASTER_P_SIMPLIFY_DESCRIPTION = "Simplifier tollerance.";
+    public static final String OMSLINESMOOTHERMCMASTER_OUT_VECTOR_DESCRIPTION = "The vector with smoothed features.";
 
     public static final String OMSVECTORCONVERTER_DESCRIPTION = "A simple middleman module to do feature conversion.";
     public static final String OMSVECTORCONVERTER_DOCUMENTATION = "";
@@ -80,8 +80,8 @@ public class GearsMessages {
     public static final String OMSVECTORCONVERTER_AUTHORNAMES = "Andrea Antonello";
     public static final String OMSVECTORCONVERTER_AUTHORCONTACTS = "www.hydrologis.com";
     public static final String OMSVECTORCONVERTER_UI = "hide";
-    public static final String OMSVECTORCONVERTER_inGeodata_DESCRIPTION = "The input features.";
-    public static final String OMSVECTORCONVERTER_outGeodata_DESCRIPTION = "The output features.";
+    public static final String OMSVECTORCONVERTER_IN_GEODATA_DESCRIPTION = "The input features.";
+    public static final String OMSVECTORCONVERTER_OUT_GEODATA_DESCRIPTION = "The output features.";
 
     public static final String OMSTIMESERIESITERATORWRITER_DESCRIPTION = "Utility class for writing a id2values map to a OMS formatted csv file.";
     public static final String OMSTIMESERIESITERATORWRITER_DOCUMENTATION = "OmsTimeSeriesIteratorWriter.html";
@@ -92,12 +92,12 @@ public class GearsMessages {
     public static final String OMSTIMESERIESITERATORWRITER_LICENSE = "General Public License Version 3 (GPLv3)";
     public static final String OMSTIMESERIESITERATORWRITER_AUTHORNAMES = "Andrea Antonello";
     public static final String OMSTIMESERIESITERATORWRITER_AUTHORCONTACTS = "http://www.hydrologis.com";
-    public static final String OMSTIMESERIESITERATORWRITER_file_DESCRIPTION = "The csv file to write to.";
-    public static final String OMSTIMESERIESITERATORWRITER_inTablename_DESCRIPTION = "The table name.";
-    public static final String OMSTIMESERIESITERATORWRITER_inData_DESCRIPTION = "The hashmap of ids and values to write.";
-    public static final String OMSTIMESERIESITERATORWRITER_tStart_DESCRIPTION = "The start date. If available time is added as first column.";
-    public static final String OMSTIMESERIESITERATORWRITER_tTimestep_DESCRIPTION = "The timestep. If available time is added as first column.";
-    public static final String OMSTIMESERIESITERATORWRITER_fileNovalue_DESCRIPTION = "The novalue to use in the file (default is -9999.0).";
+    public static final String OMSTIMESERIESITERATORWRITER_FILE_DESCRIPTION = "The csv file to write to.";
+    public static final String OMSTIMESERIESITERATORWRITER_IN_TABLENAME_DESCRIPTION = "The table name.";
+    public static final String OMSTIMESERIESITERATORWRITER_IN_DATA_DESCRIPTION = "The hashmap of ids and values to write.";
+    public static final String OMSTIMESERIESITERATORWRITER_T_START_DESCRIPTION = "The start date. If available time is added as first column.";
+    public static final String OMSTIMESERIESITERATORWRITER_T_TIMESTEP_DESCRIPTION = "The timestep. If available time is added as first column.";
+    public static final String OMSTIMESERIESITERATORWRITER_FILE_NOVALUE_DESCRIPTION = "The novalue to use in the file (default is -9999.0).";
 
     public static final String OMSLINESRASTERIZER_DESCRIPTION = "Module to convert vector lines to raster.";
     public static final String OMSLINESRASTERIZER_DOCUMENTATION = "";
@@ -108,16 +108,16 @@ public class GearsMessages {
     public static final String OMSLINESRASTERIZER_LICENSE = "General Public License Version 3 (GPLv3)";
     public static final String OMSLINESRASTERIZER_AUTHORNAMES = "Andrea Antonello";
     public static final String OMSLINESRASTERIZER_AUTHORCONTACTS = "http://www.hydrologis.com";
-    public static final String OMSLINESRASTERIZER_inVector_DESCRIPTION = "The lines vector.";
-    public static final String OMSLINESRASTERIZER_fCat_DESCRIPTION = "The optional field of the vector to take the category from.";
-    public static final String OMSLINESRASTERIZER_pCat_DESCRIPTION = "The category to use if no field was set.";
-    public static final String OMSLINESRASTERIZER_pNorth_DESCRIPTION = "The north bound of the region to consider";
-    public static final String OMSLINESRASTERIZER_pSouth_DESCRIPTION = "The south bound of the region to consider";
-    public static final String OMSLINESRASTERIZER_pWest_DESCRIPTION = "The west bound of the region to consider";
-    public static final String OMSLINESRASTERIZER_pEast_DESCRIPTION = "The east bound of the region to consider";
-    public static final String OMSLINESRASTERIZER_pRows_DESCRIPTION = "The rows of the region to consider";
-    public static final String OMSLINESRASTERIZER_pCols_DESCRIPTION = "The cols of the region to consider";
-    public static final String OMSLINESRASTERIZER_outRaster_DESCRIPTION = "The output raster.";
+    public static final String OMSLINESRASTERIZER_IN_VECTOR_DESCRIPTION = "The lines vector.";
+    public static final String OMSLINESRASTERIZER_F_CAT_DESCRIPTION = "The optional field of the vector to take the category from.";
+    public static final String OMSLINESRASTERIZER_P_CAT_DESCRIPTION = "The category to use if no field was set.";
+    public static final String OMSLINESRASTERIZER_P_NORTH_DESCRIPTION = "The north bound of the region to consider";
+    public static final String OMSLINESRASTERIZER_P_SOUTH_DESCRIPTION = "The south bound of the region to consider";
+    public static final String OMSLINESRASTERIZER_P_WEST_DESCRIPTION = "The west bound of the region to consider";
+    public static final String OMSLINESRASTERIZER_P_EAST_DESCRIPTION = "The east bound of the region to consider";
+    public static final String OMSLINESRASTERIZER_P_ROWS_DESCRIPTION = "The rows of the region to consider";
+    public static final String OMSLINESRASTERIZER_P_COLS_DESCRIPTION = "The cols of the region to consider";
+    public static final String OMSLINESRASTERIZER_OUT_RASTER_DESCRIPTION = "The output raster.";
 
     public static final String OMSCONTOURLINESLABELER_DESCRIPTION = "Generates a layer of point features with a given label text and angle, following reference lines intersecting them with a layer of countourlines.";
     public static final String OMSCONTOURLINESLABELER_DOCUMENTATION = "";
@@ -128,11 +128,11 @@ public class GearsMessages {
     public static final String OMSCONTOURLINESLABELER_LICENSE = "http://www.gnu.org/licenses/gpl-3.0.html";
     public static final String OMSCONTOURLINESLABELER_AUTHORNAMES = "Andrea Antonello";
     public static final String OMSCONTOURLINESLABELER_AUTHORCONTACTS = "www.hydrologis.com";
-    public static final String OMSCONTOURLINESLABELER_inContour_DESCRIPTION = "The contour lines.";
-    public static final String OMSCONTOURLINESLABELER_fElevation_DESCRIPTION = "Field name of the contour elevation";
-    public static final String OMSCONTOURLINESLABELER_inLines_DESCRIPTION = "The lines to intersect with the contours to generate label points.";
-    public static final String OMSCONTOURLINESLABELER_buffer_DESCRIPTION = "The buffer to consider for every line.";
-    public static final String OMSCONTOURLINESLABELER_outPoints_DESCRIPTION = "The labeled point layer.";
+    public static final String OMSCONTOURLINESLABELER_IN_CONTOUR_DESCRIPTION = "The contour lines.";
+    public static final String OMSCONTOURLINESLABELER_F_ELEVATION_DESCRIPTION = "Field name of the contour elevation";
+    public static final String OMSCONTOURLINESLABELER_INLINES_DESCRIPTION = "The lines to intersect with the contours to generate label points.";
+    public static final String OMSCONTOURLINESLABELER_BUFFER_DESCRIPTION = "The buffer to consider for every line.";
+    public static final String OMSCONTOURLINESLABELER_OUTPOINTS_DESCRIPTION = "The labeled point layer.";
 
     public static final String EXIFREADER_DESCRIPTION = "Utility class for reading exif tags in jpegs.";
     public static final String EXIFREADER_DOCUMENTATION = "";
@@ -143,8 +143,8 @@ public class GearsMessages {
     public static final String EXIFREADER_LICENSE = "http://www.gnu.org/licenses/gpl-3.0.html";
     public static final String EXIFREADER_AUTHORNAMES = "Andrea Antonello";
     public static final String EXIFREADER_AUTHORCONTACTS = "www.hydrologis.com";
-    public static final String EXIFREADER_file_DESCRIPTION = "The jpeg file.";
-    public static final String EXIFREADER_outTags_DESCRIPTION = "The read exif tags.";
+    public static final String EXIFREADER_FILE_DESCRIPTION = "The jpeg file.";
+    public static final String EXIFREADER_OUTTAGS_DESCRIPTION = "The read exif tags.";
 
     public static final String OMSGRASSLEGACYREADER_DESCRIPTION = "Legacy class for reading grass data the old way.";
     public static final String OMSGRASSLEGACYREADER_DOCUMENTATION = "";
@@ -156,11 +156,11 @@ public class GearsMessages {
     public static final String OMSGRASSLEGACYREADER_AUTHORNAMES = "Andrea Antonello";
     public static final String OMSGRASSLEGACYREADER_AUTHORCONTACTS = "http://www.hydrologis.com";
     public static final String OMSGRASSLEGACYREADER_UI = "hide";
-    public static final String OMSGRASSLEGACYREADER_file_DESCRIPTION = "The file to the map to be read (the cell file).";
-    public static final String OMSGRASSLEGACYREADER_doActive_DESCRIPTION = "Flag that defines if the map should be read as a whole (false) or on the active region (true and default).";
-    public static final String OMSGRASSLEGACYREADER_inWindow_DESCRIPTION = "The region to read.";
-    public static final String OMSGRASSLEGACYREADER_outGC_DESCRIPTION = "The read output map as limited coverage version.";
-    public static final String OMSGRASSLEGACYREADER_geodata_DESCRIPTION = "The read output map data.";
+    public static final String OMSGRASSLEGACYREADER_FILE_DESCRIPTION = "The file to the map to be read (the cell file).";
+    public static final String OMSGRASSLEGACYREADER_DOACTIVE_DESCRIPTION = "Flag that defines if the map should be read as a whole (false) or on the active region (true and default).";
+    public static final String OMSGRASSLEGACYREADER_IN_WINDOW_DESCRIPTION = "The region to read.";
+    public static final String OMSGRASSLEGACYREADER_OUT_GC_DESCRIPTION = "The read output map as limited coverage version.";
+    public static final String OMSGRASSLEGACYREADER_GEO_DATA_DESCRIPTION = "The read output map data.";
 
     public static final String OMSMATRIXCHARTER_DESCRIPTION = "Utility class for charting matrix data.";
     public static final String OMSMATRIXCHARTER_DOCUMENTATION = "";
@@ -172,24 +172,24 @@ public class GearsMessages {
     public static final String OMSMATRIXCHARTER_AUTHORNAMES = "Andrea Antonello";
     public static final String OMSMATRIXCHARTER_AUTHORCONTACTS = "http://www.hydrologis.com";
     public static final String OMSMATRIXCHARTER_UI = "hide";
-    public static final String OMSMATRIXCHARTER_inData_DESCRIPTION = "The matrix to chart.";
-    public static final String OMSMATRIXCHARTER_inTitle_DESCRIPTION = "The data title.";
-    public static final String OMSMATRIXCHARTER_inSubTitle_DESCRIPTION = "The subtitle.";
-    public static final String OMSMATRIXCHARTER_inSeries_DESCRIPTION = "The data series names.";
-    public static final String OMSMATRIXCHARTER_inColors_DESCRIPTION = "The optional data series colors. Format is rbg triplets delimited by semicolon: ex. 0,0,255;0,255,0;255,0,0. The colors have to be the same number as the series.";
-    public static final String OMSMATRIXCHARTER_inLabels_DESCRIPTION = "The axis labels (x, y1, y2, ...).";
-    public static final String OMSMATRIXCHARTER_inFormats_DESCRIPTION = "The data formats (dates and numeric formatting patterns).";
-    public static final String OMSMATRIXCHARTER_inTypes_DESCRIPTION = "The data types (dates or numerics like double, int).";
-    public static final String OMSMATRIXCHARTER_pType_DESCRIPTION = "Chart type: 0 = line, 1 = histogram (default is 0).";
-    public static final String OMSMATRIXCHARTER_doChart_DESCRIPTION = "Chart the data.";
-    public static final String OMSMATRIXCHARTER_doDump_DESCRIPTION = "Dump the chart to disk.";
-    public static final String OMSMATRIXCHARTER_doLegend_DESCRIPTION = "Show the legend.";
-    public static final String OMSMATRIXCHARTER_doPoints_DESCRIPTION = "Show shapes in line charts.";
-    public static final String OMSMATRIXCHARTER_doCumulate_DESCRIPTION = "Cumulate data.";
-    public static final String OMSMATRIXCHARTER_doNormalize_DESCRIPTION = "Normalize data.";
-    public static final String OMSMATRIXCHARTER_pWidth_DESCRIPTION = "Chart image width (in case of doDump=true, defaults to 800 px).";
-    public static final String OMSMATRIXCHARTER_pHeight_DESCRIPTION = "Chart image height (in case of doDump=true, defaults to 600 px).";
-    public static final String OMSMATRIXCHARTER_inChartPath_DESCRIPTION = "Chart dump path (in case of doDump=true).";
+    public static final String OMSMATRIXCHARTER_IN_DATA_DESCRIPTION = "The matrix to chart.";
+    public static final String OMSMATRIXCHARTER_IN_TITLE_DESCRIPTION = "The data title.";
+    public static final String OMSMATRIXCHARTER_IN_SUBTITLE_DESCRIPTION = "The subtitle.";
+    public static final String OMSMATRIXCHARTER_IN_SERIES_DESCRIPTION = "The data series names.";
+    public static final String OMSMATRIXCHARTER_IN_COLORS_DESCRIPTION = "The optional data series colors. Format is rbg triplets delimited by semicolon: ex. 0,0,255;0,255,0;255,0,0. The colors have to be the same number as the series.";
+    public static final String OMSMATRIXCHARTER_IN_LABELS_DESCRIPTION = "The axis labels (x, y1, y2, ...).";
+    public static final String OMSMATRIXCHARTER_IN_FORMATS_DESCRIPTION = "The data formats (dates and numeric formatting patterns).";
+    public static final String OMSMATRIXCHARTER_IN_TYPES_DESCRIPTION = "The data types (dates or numerics like double, int).";
+    public static final String OMSMATRIXCHARTER_P_TYPE_DESCRIPTION = "Chart type: 0 = line, 1 = histogram (default is 0).";
+    public static final String OMSMATRIXCHARTER_DO_CHART_DESCRIPTION = "Chart the data.";
+    public static final String OMSMATRIXCHARTER_DO_DUMP_DESCRIPTION = "Dump the chart to disk.";
+    public static final String OMSMATRIXCHARTER_DO_LEGEND_DESCRIPTION = "Show the legend.";
+    public static final String OMSMATRIXCHARTER_DO_POINTS_DESCRIPTION = "Show shapes in line charts.";
+    public static final String OMSMATRIXCHARTER_DO_CUMULATE_DESCRIPTION = "Cumulate data.";
+    public static final String OMSMATRIXCHARTER_DO_NORMALIZE_DESCRIPTION = "Normalize data.";
+    public static final String OMSMATRIXCHARTER_P_WIDTH_DESCRIPTION = "Chart image width (in case of doDump=true, defaults to 800 px).";
+    public static final String OMSMATRIXCHARTER_P_HEIGHT_DESCRIPTION = "Chart image height (in case of doDump=true, defaults to 600 px).";
+    public static final String OMSMATRIXCHARTER_IN_CHARTPATH_DESCRIPTION = "Chart dump path (in case of doDump=true).";
 
     public static final String OMSRASTERVECTORINTERSECTOR_DESCRIPTION = "Module for raster with polygon vector intersection.";
     public static final String OMSRASTERVECTORINTERSECTOR_DOCUMENTATION = "";
@@ -200,10 +200,10 @@ public class GearsMessages {
     public static final String OMSRASTERVECTORINTERSECTOR_LICENSE = "General Public License Version 3 (GPLv3)";
     public static final String OMSRASTERVECTORINTERSECTOR_AUTHORNAMES = "Andrea Antonello";
     public static final String OMSRASTERVECTORINTERSECTOR_AUTHORCONTACTS = "http://www.hydrologis.com";
-    public static final String OMSRASTERVECTORINTERSECTOR_inVector_DESCRIPTION = "The polygon vector to use for the intersection.";
-    public static final String OMSRASTERVECTORINTERSECTOR_inRaster_DESCRIPTION = "The raster to use for the intersection.";
-    public static final String OMSRASTERVECTORINTERSECTOR_doInverse_DESCRIPTION = "Flag to use to invert the result (default is false = keep data inside vector)";
-    public static final String OMSRASTERVECTORINTERSECTOR_outRaster_DESCRIPTION = "The output raster.";
+    public static final String OMSRASTERVECTORINTERSECTOR_IN_VECTOR_DESCRIPTION = "The polygon vector to use for the intersection.";
+    public static final String OMSRASTERVECTORINTERSECTOR_IN_RASTER_DESCRIPTION = "The raster to use for the intersection.";
+    public static final String OMSRASTERVECTORINTERSECTOR_DO_INVERSE_DESCRIPTION = "Flag to use to invert the result (default is false = keep data inside vector)";
+    public static final String OMSRASTERVECTORINTERSECTOR_OUT_RASTER_DESCRIPTION = "The output raster.";
 
     public static final String OMSPOINTSVECTORIZER_DESCRIPTION = "Module that creates a points vector layer from raster values.";
     public static final String OMSPOINTSVECTORIZER_DOCUMENTATION = "";
@@ -214,9 +214,9 @@ public class GearsMessages {
     public static final String OMSPOINTSVECTORIZER_LICENSE = "General Public License Version 3 (GPLv3)";
     public static final String OMSPOINTSVECTORIZER_AUTHORNAMES = "Andrea Antonello";
     public static final String OMSPOINTSVECTORIZER_AUTHORCONTACTS = "http://www.hydrologis.com";
-    public static final String OMSPOINTSVECTORIZER_inRaster_DESCRIPTION = "The raster that has to be converted.";
-    public static final String OMSPOINTSVECTORIZER_fDefault_DESCRIPTION = "The field name to use as a name for the raster value in the vector.";
-    public static final String OMSPOINTSVECTORIZER_outVector_DESCRIPTION = "The extracted vector.";
+    public static final String OMSPOINTSVECTORIZER_IN_RASTER_DESCRIPTION = "The raster that has to be converted.";
+    public static final String OMSPOINTSVECTORIZER_F_DEFAULT_DESCRIPTION = "The field name to use as a name for the raster value in the vector.";
+    public static final String OMSPOINTSVECTORIZER_OUT_VECTOR_DESCRIPTION = "The extracted vector.";
 
     public static final String OMSLINESVECTORIZER_DESCRIPTION = "Module that creates a lines vector layer from a thinned raster.";
     public static final String OMSLINESVECTORIZER_DOCUMENTATION = "";
@@ -227,9 +227,9 @@ public class GearsMessages {
     public static final String OMSLINESVECTORIZER_LICENSE = "General Public License Version 3 (GPLv3)";
     public static final String OMSLINESVECTORIZER_AUTHORNAMES = "Andrea Antonello";
     public static final String OMSLINESVECTORIZER_AUTHORCONTACTS = "http://www.hydrologis.com";
-    public static final String OMSLINESVECTORIZER_inRaster_DESCRIPTION = "The raster that has to be converted.";
-    public static final String OMSLINESVECTORIZER_fDefault_DESCRIPTION = "The field name to use as a name for the raster value in the vector.";
-    public static final String OMSLINESVECTORIZER_outVector_DESCRIPTION = "The extracted vector.";
+    public static final String OMSLINESVECTORIZER_IN_RASTER_DESCRIPTION = "The raster that has to be converted.";
+    public static final String OMSLINESVECTORIZER_F_DEFAULT_DESCRIPTION = "The field name to use as a name for the raster value in the vector.";
+    public static final String OMSLINESVECTORIZER_OUT_VECTOR_DESCRIPTION = "The extracted vector.";
 
     public static final String OMSVECTORREADER_DESCRIPTION = "Vectors features reader module.";
     public static final String OMSVECTORREADER_DOCUMENTATION = "OmsVectorReader.html";
@@ -240,9 +240,9 @@ public class GearsMessages {
     public static final String OMSVECTORREADER_LICENSE = "General Public License Version 3 (GPLv3)";
     public static final String OMSVECTORREADER_AUTHORNAMES = "Andrea Antonello";
     public static final String OMSVECTORREADER_AUTHORCONTACTS = "http://www.hydrologis.com";
-    public static final String OMSVECTORREADER_pType_DESCRIPTION = "The vector type to read (Supported is: shp, properties).";
-    public static final String OMSVECTORREADER_file_DESCRIPTION = "The vector file to read.";
-    public static final String OMSVECTORREADER_outVector_DESCRIPTION = "The read feature collection.";
+    public static final String OMSVECTORREADER_P_TYPE_DESCRIPTION = "The vector type to read (Supported is: shp, properties).";
+    public static final String OMSVECTORREADER_FILE_DESCRIPTION = "The vector file to read.";
+    public static final String OMSVECTORREADER_OUT_VECTOR_DESCRIPTION = "The read feature collection.";
 
     public static final String OMSRASTERWRITER_DESCRIPTION = "Raster writer module.";
     public static final String OMSRASTERWRITER_DOCUMENTATION = "OmsRasterWriter.html";
@@ -253,8 +253,8 @@ public class GearsMessages {
     public static final String OMSRASTERWRITER_LICENSE = "General Public License Version 3 (GPLv3)";
     public static final String OMSRASTERWRITER_AUTHORNAMES = "Andrea Antonello";
     public static final String OMSRASTERWRITER_AUTHORCONTACTS = "http://www.hydrologis.com";
-    public static final String OMSRASTERWRITER_inRaster_DESCRIPTION = "The raster map to write.";
-    public static final String OMSRASTERWRITER_file_DESCRIPTION = "The file to write the raster to with extension (supported are: asc, tiff, grass).";
+    public static final String OMSRASTERWRITER_IN_RASTER_DESCRIPTION = "The raster map to write.";
+    public static final String OMSRASTERWRITER_FILE_DESCRIPTION = "The file to write the raster to with extension (supported are: asc, tiff, grass).";
 
     public static final String OMSGROUNDCONTROLPOINTS2WORLD_DESCRIPTION = "A module to calculate world file coefficients from set of GCPs";
     public static final String OMSGROUNDCONTROLPOINTS2WORLD_DOCUMENTATION = "";
@@ -265,25 +265,25 @@ public class GearsMessages {
     public static final String OMSGROUNDCONTROLPOINTS2WORLD_LICENSE = "General Public License Version 3 (GPLv3)";
     public static final String OMSGROUNDCONTROLPOINTS2WORLD_AUTHORNAMES = "Jan Jezek";
     public static final String OMSGROUNDCONTROLPOINTS2WORLD_AUTHORCONTACTS = "http://code.google.com/p/oldmapsonline/";
-    public static final String OMSGROUNDCONTROLPOINTS2WORLD_inFile_DESCRIPTION = "The file containing the ground control points.";
-    public static final String OMSGROUNDCONTROLPOINTS2WORLD_pSkew_DESCRIPTION = "pSkew";
-    public static final String OMSGROUNDCONTROLPOINTS2WORLD_pPhix_DESCRIPTION = "pPhix";
-    public static final String OMSGROUNDCONTROLPOINTS2WORLD_pPhiy_DESCRIPTION = "pPhiy";
-    public static final String OMSGROUNDCONTROLPOINTS2WORLD_pTx_DESCRIPTION = "pTx";
-    public static final String OMSGROUNDCONTROLPOINTS2WORLD_pTy_DESCRIPTION = "pTy";
-    public static final String OMSGROUNDCONTROLPOINTS2WORLD_pSx_DESCRIPTION = "pSx";
-    public static final String OMSGROUNDCONTROLPOINTS2WORLD_pSy_DESCRIPTION = "pSy";
-    public static final String OMSGROUNDCONTROLPOINTS2WORLD_doSimilar_DESCRIPTION = "doSimilar";
-    public static final String OMSGROUNDCONTROLPOINTS2WORLD_outScaley_DESCRIPTION = "outScaley";
-    public static final String OMSGROUNDCONTROLPOINTS2WORLD_outScalex_DESCRIPTION = "outScalex";
-    public static final String OMSGROUNDCONTROLPOINTS2WORLD_outSheary_DESCRIPTION = "outSheary";
-    public static final String OMSGROUNDCONTROLPOINTS2WORLD_outShearx_DESCRIPTION = "outShearx";
-    public static final String OMSGROUNDCONTROLPOINTS2WORLD_outTranslatex_DESCRIPTION = "outTranslatex";
-    public static final String OMSGROUNDCONTROLPOINTS2WORLD_outTranslatey_DESCRIPTION = "outTranslatey";
-    public static final String OMSGROUNDCONTROLPOINTS2WORLD_outErrmean_DESCRIPTION = "outErrmean";
-    public static final String OMSGROUNDCONTROLPOINTS2WORLD_outErrrms_DESCRIPTION = "outErrrms";
-    public static final String OMSGROUNDCONTROLPOINTS2WORLD_outErrmax_DESCRIPTION = "outErrmax";
-    public static final String OMSGROUNDCONTROLPOINTS2WORLD_outErrmin_DESCRIPTION = "outErrmin";
+    public static final String OMSGROUNDCONTROLPOINTS2WORLD_IN_FILE_DESCRIPTION = "The file containing the ground control points.";
+    public static final String OMSGROUNDCONTROLPOINTS2WORLD_P_SKEW_DESCRIPTION = "pSkew";
+    public static final String OMSGROUNDCONTROLPOINTS2WORLD_P_PHIX_DESCRIPTION = "pPhix";
+    public static final String OMSGROUNDCONTROLPOINTS2WORLD_P_PHIY_DESCRIPTION = "pPhiy";
+    public static final String OMSGROUNDCONTROLPOINTS2WORLD_P_T_X_DESCRIPTION = "pTx";
+    public static final String OMSGROUNDCONTROLPOINTS2WORLD_P_T_Y_DESCRIPTION = "pTy";
+    public static final String OMSGROUNDCONTROLPOINTS2WORLD_P_S_X_DESCRIPTION = "pSx";
+    public static final String OMSGROUNDCONTROLPOINTS2WORLD_P_S_Y_DESCRIPTION = "pSy";
+    public static final String OMSGROUNDCONTROLPOINTS2WORLD_DO_SIMILAR_DESCRIPTION = "doSimilar";
+    public static final String OMSGROUNDCONTROLPOINTS2WORLD_OUT_SCALE_Y_DESCRIPTION = "outScaley";
+    public static final String OMSGROUNDCONTROLPOINTS2WORLD_OUT_SCALE_X_DESCRIPTION = "outScalex";
+    public static final String OMSGROUNDCONTROLPOINTS2WORLD_OUT_SHEAR_Y_DESCRIPTION = "outSheary";
+    public static final String OMSGROUNDCONTROLPOINTS2WORLD_OUT_SHEAR_X_DESCRIPTION = "outShearx";
+    public static final String OMSGROUNDCONTROLPOINTS2WORLD_OUT_TRANSLATE_X_DESCRIPTION = "outTranslatex";
+    public static final String OMSGROUNDCONTROLPOINTS2WORLD_OUT_TRANSLATE_Y_DESCRIPTION = "outTranslatey";
+    public static final String OMSGROUNDCONTROLPOINTS2WORLD_OUT_ERR_MEAN_DESCRIPTION = "outErrmean";
+    public static final String OMSGROUNDCONTROLPOINTS2WORLD_OUT_ERR_RMS_DESCRIPTION = "outErrrms";
+    public static final String OMSGROUNDCONTROLPOINTS2WORLD_OUT_ERR_MAX_DESCRIPTION = "outErrmax";
+    public static final String OMSGROUNDCONTROLPOINTS2WORLD_OUT_ERR_MIN_DESCRIPTION = "outErrmin";
 
     public static final String OMSWINDOWSAMPLER_DESCRIPTION = "Module to do coverage downsampling on defined windows.";
     public static final String OMSWINDOWSAMPLER_DOCUMENTATION = "";
@@ -294,14 +294,14 @@ public class GearsMessages {
     public static final String OMSWINDOWSAMPLER_LICENSE = "http://www.gnu.org/licenses/gpl-3.0.html";
     public static final String OMSWINDOWSAMPLER_AUTHORNAMES = "Andrea Antonello";
     public static final String OMSWINDOWSAMPLER_AUTHORCONTACTS = "www.hydrologis.com";
-    public static final String OMSWINDOWSAMPLER_inGeodata_DESCRIPTION = "The input coverage.";
-    public static final String OMSWINDOWSAMPLER_pMode_DESCRIPTION = "The mode to use: average (0 = default), sum (1), max (2), min (3).";
-    public static final String OMSWINDOWSAMPLER_pRows_DESCRIPTION = "The windows rows to use (default is 3).";
-    public static final String OMSWINDOWSAMPLER_pCols_DESCRIPTION = "The window cols to use (default is 3).";
-    public static final String OMSWINDOWSAMPLER_pMinvalid_DESCRIPTION = "Minimum percentage of valid surrounding cells needed to validate the maximum.";
-    public static final String OMSWINDOWSAMPLER_pXstep_DESCRIPTION = "The cols to move the window forward (default is = pCols).";
-    public static final String OMSWINDOWSAMPLER_pYstep_DESCRIPTION = "The rows to move the window forward (default is = pRows).";
-    public static final String OMSWINDOWSAMPLER_outGeodata_DESCRIPTION = "The output coverage.";
+    public static final String OMSWINDOWSAMPLER_IN_GEODATA_DESCRIPTION = "The input coverage.";
+    public static final String OMSWINDOWSAMPLER_P_MODE_DESCRIPTION = "The mode to use: average (0 = default), sum (1), max (2), min (3).";
+    public static final String OMSWINDOWSAMPLER_P_ROWS_DESCRIPTION = "The windows rows to use (default is 3).";
+    public static final String OMSWINDOWSAMPLER_P_COLS_DESCRIPTION = "The window cols to use (default is 3).";
+    public static final String OMSWINDOWSAMPLER_P_MIN_VALID_DESCRIPTION = "Minimum percentage of valid surrounding cells needed to validate the maximum.";
+    public static final String OMSWINDOWSAMPLER_P_X_STEP_DESCRIPTION = "The cols to move the window forward (default is = pCols).";
+    public static final String OMSWINDOWSAMPLER_P_Y_STEP_DESCRIPTION = "The rows to move the window forward (default is = pRows).";
+    public static final String OMSWINDOWSAMPLER_OUT_GEODATA_DESCRIPTION = "The output coverage.";
 
     public static final String OMSRASTERREADER_DESCRIPTION = "Raster reader module.";
     public static final String OMSRASTERREADER_DOCUMENTATION = "OmsRasterReader.html";
@@ -1547,5 +1547,7 @@ public class GearsMessages {
     public static final String OMSVECTORREPROJECTOR_pForceCode_DESCRIPTION = "A coordinate reference system on which to force the input, composed by authority and code number (ex. EPSG:4328).";
     public static final String OMSVECTORREPROJECTOR_doLenient_DESCRIPTION = "Switch that set to true allows for some error due to different datums. If set to false, it won't reproject without Bursa Wolf parameters.";
     public static final String OMSVECTORREPROJECTOR_outVector_DESCRIPTION = "The output reprojected vector.";
+
+    private GearsMessages() {}
 
 }

--- a/jgrassgears/src/main/java/org/jgrasstools/gears/io/exif/ExifReader.java
+++ b/jgrassgears/src/main/java/org/jgrasstools/gears/io/exif/ExifReader.java
@@ -26,8 +26,8 @@ import static org.jgrasstools.gears.i18n.GearsMessages.EXIFREADER_LABEL;
 import static org.jgrasstools.gears.i18n.GearsMessages.EXIFREADER_LICENSE;
 import static org.jgrasstools.gears.i18n.GearsMessages.EXIFREADER_NAME;
 import static org.jgrasstools.gears.i18n.GearsMessages.EXIFREADER_STATUS;
-import static org.jgrasstools.gears.i18n.GearsMessages.EXIFREADER_file_DESCRIPTION;
-import static org.jgrasstools.gears.i18n.GearsMessages.EXIFREADER_outTags_DESCRIPTION;
+import static org.jgrasstools.gears.i18n.GearsMessages.EXIFREADER_FILE_DESCRIPTION;
+import static org.jgrasstools.gears.i18n.GearsMessages.EXIFREADER_OUTTAGS_DESCRIPTION;
 
 import java.io.File;
 import java.io.IOException;
@@ -61,11 +61,11 @@ import org.w3c.dom.NodeList;
 @License(EXIFREADER_LICENSE)
 public class ExifReader extends JGTModel {
 
-    @Description(EXIFREADER_file_DESCRIPTION)
+    @Description(EXIFREADER_FILE_DESCRIPTION)
     @In
     public String file = null;
 
-    @Description(EXIFREADER_outTags_DESCRIPTION)
+    @Description(EXIFREADER_OUTTAGS_DESCRIPTION)
     @Out
     public HashMap<String, ExifTag> outTags = null;
 

--- a/jgrassgears/src/main/java/org/jgrasstools/gears/io/geopaparazzi/OmsGeopaparazzi3Converter.java
+++ b/jgrassgears/src/main/java/org/jgrasstools/gears/io/geopaparazzi/OmsGeopaparazzi3Converter.java
@@ -57,28 +57,28 @@ import static org.jgrasstools.gears.i18n.GearsMessages.*;
 @License(OMSHYDRO_LICENSE)
 public class OmsGeopaparazzi3Converter extends JGTModel {
 
-    @Description(OMSGEOPAPARAZZICONVERTER_inGeopaparazzi_DESCRIPTION)
+    @Description(OMSGEOPAPARAZZICONVERTER_IN_GEOPAPARAZZI_DESCRIPTION)
     @UI(JGTConstants.FOLDERIN_UI_HINT)
     @In
     public String inGeopaparazzi = null;
 
-    @Description(OMSGEOPAPARAZZICONVERTER_doNotes_DESCRIPTION)
+    @Description(OMSGEOPAPARAZZICONVERTER_DO_NOTES_DESCRIPTION)
     @In
     public boolean doNotes = true;
 
-    @Description(OMSGEOPAPARAZZICONVERTER_doLoglines_DESCRIPTION)
+    @Description(OMSGEOPAPARAZZICONVERTER_DO_LOG_LINES_DESCRIPTION)
     @In
     public boolean doLoglines = true;
 
-    @Description(OMSGEOPAPARAZZICONVERTER_doLogpoints_DESCRIPTION)
+    @Description(OMSGEOPAPARAZZICONVERTER_DO_LOG_POINTS_DESCRIPTION)
     @In
     public boolean doLogpoints = false;
 
-    @Description(OMSGEOPAPARAZZICONVERTER_doMedia_DESCRIPTION)
+    @Description(OMSGEOPAPARAZZICONVERTER_DO_MEDIA_DESCRIPTION)
     @In
     public boolean doMedia = true;
 
-    @Description(OMSGEOPAPARAZZICONVERTER_outData_DESCRIPTION)
+    @Description(OMSGEOPAPARAZZICONVERTER_OUTDATA_DESCRIPTION)
     @UI(JGTConstants.FOLDEROUT_UI_HINT)
     @In
     public String outData = null;

--- a/jgrassgears/src/main/java/org/jgrasstools/gears/io/geopaparazzi/OmsGeopaparazzi4Converter.java
+++ b/jgrassgears/src/main/java/org/jgrasstools/gears/io/geopaparazzi/OmsGeopaparazzi4Converter.java
@@ -37,11 +37,11 @@ package org.jgrasstools.gears.io.geopaparazzi;
 
 import static org.jgrasstools.gears.i18n.GearsMessages.OMSGEOPAPARAZZICONVERTER_NAME;
 import static org.jgrasstools.gears.i18n.GearsMessages.OMSGEOPAPARAZZICONVERTER_TAGS;
-import static org.jgrasstools.gears.i18n.GearsMessages.OMSGEOPAPARAZZICONVERTER_doLoglines_DESCRIPTION;
-import static org.jgrasstools.gears.i18n.GearsMessages.OMSGEOPAPARAZZICONVERTER_doLogpoints_DESCRIPTION;
-import static org.jgrasstools.gears.i18n.GearsMessages.OMSGEOPAPARAZZICONVERTER_doMedia_DESCRIPTION;
-import static org.jgrasstools.gears.i18n.GearsMessages.OMSGEOPAPARAZZICONVERTER_doNotes_DESCRIPTION;
-import static org.jgrasstools.gears.i18n.GearsMessages.OMSGEOPAPARAZZICONVERTER_outData_DESCRIPTION;
+import static org.jgrasstools.gears.i18n.GearsMessages.OMSGEOPAPARAZZICONVERTER_DO_LOG_LINES_DESCRIPTION;
+import static org.jgrasstools.gears.i18n.GearsMessages.OMSGEOPAPARAZZICONVERTER_DO_LOG_POINTS_DESCRIPTION;
+import static org.jgrasstools.gears.i18n.GearsMessages.OMSGEOPAPARAZZICONVERTER_DO_MEDIA_DESCRIPTION;
+import static org.jgrasstools.gears.i18n.GearsMessages.OMSGEOPAPARAZZICONVERTER_DO_NOTES_DESCRIPTION;
+import static org.jgrasstools.gears.i18n.GearsMessages.OMSGEOPAPARAZZICONVERTER_OUTDATA_DESCRIPTION;
 import static org.jgrasstools.gears.i18n.GearsMessages.OMSHYDRO_AUTHORCONTACTS;
 import static org.jgrasstools.gears.i18n.GearsMessages.OMSHYDRO_AUTHORNAMES;
 import static org.jgrasstools.gears.i18n.GearsMessages.OMSHYDRO_DRAFT;
@@ -133,23 +133,23 @@ public class OmsGeopaparazzi4Converter extends JGTModel {
     @In
     public String inGeopaparazzi = null;
 
-    @Description(OMSGEOPAPARAZZICONVERTER_doNotes_DESCRIPTION)
+    @Description(OMSGEOPAPARAZZICONVERTER_DO_NOTES_DESCRIPTION)
     @In
     public boolean doNotes = true;
 
-    @Description(OMSGEOPAPARAZZICONVERTER_doLoglines_DESCRIPTION)
+    @Description(OMSGEOPAPARAZZICONVERTER_DO_LOG_LINES_DESCRIPTION)
     @In
     public boolean doLoglines = true;
 
-    @Description(OMSGEOPAPARAZZICONVERTER_doLogpoints_DESCRIPTION)
+    @Description(OMSGEOPAPARAZZICONVERTER_DO_LOG_POINTS_DESCRIPTION)
     @In
     public boolean doLogpoints = false;
 
-    @Description(OMSGEOPAPARAZZICONVERTER_doMedia_DESCRIPTION)
+    @Description(OMSGEOPAPARAZZICONVERTER_DO_MEDIA_DESCRIPTION)
     @In
     public boolean doMedia = true;
 
-    @Description(OMSGEOPAPARAZZICONVERTER_outData_DESCRIPTION)
+    @Description(OMSGEOPAPARAZZICONVERTER_OUTDATA_DESCRIPTION)
     @UI(JGTConstants.FOLDEROUT_UI_HINT)
     @In
     public String outFolder = null;

--- a/jgrassgears/src/main/java/org/jgrasstools/gears/io/grasslegacy/OmsGrassLegacyReader.java
+++ b/jgrassgears/src/main/java/org/jgrasstools/gears/io/grasslegacy/OmsGrassLegacyReader.java
@@ -26,11 +26,11 @@ import static org.jgrasstools.gears.i18n.GearsMessages.OMSGRASSLEGACYREADER_LICE
 import static org.jgrasstools.gears.i18n.GearsMessages.OMSGRASSLEGACYREADER_NAME;
 import static org.jgrasstools.gears.i18n.GearsMessages.OMSGRASSLEGACYREADER_STATUS;
 import static org.jgrasstools.gears.i18n.GearsMessages.OMSGRASSLEGACYREADER_UI;
-import static org.jgrasstools.gears.i18n.GearsMessages.OMSGRASSLEGACYREADER_doActive_DESCRIPTION;
-import static org.jgrasstools.gears.i18n.GearsMessages.OMSGRASSLEGACYREADER_file_DESCRIPTION;
-import static org.jgrasstools.gears.i18n.GearsMessages.OMSGRASSLEGACYREADER_geodata_DESCRIPTION;
-import static org.jgrasstools.gears.i18n.GearsMessages.OMSGRASSLEGACYREADER_inWindow_DESCRIPTION;
-import static org.jgrasstools.gears.i18n.GearsMessages.OMSGRASSLEGACYREADER_outGC_DESCRIPTION;
+import static org.jgrasstools.gears.i18n.GearsMessages.OMSGRASSLEGACYREADER_DOACTIVE_DESCRIPTION;
+import static org.jgrasstools.gears.i18n.GearsMessages.OMSGRASSLEGACYREADER_FILE_DESCRIPTION;
+import static org.jgrasstools.gears.i18n.GearsMessages.OMSGRASSLEGACYREADER_GEO_DATA_DESCRIPTION;
+import static org.jgrasstools.gears.i18n.GearsMessages.OMSGRASSLEGACYREADER_IN_WINDOW_DESCRIPTION;
+import static org.jgrasstools.gears.i18n.GearsMessages.OMSGRASSLEGACYREADER_OUT_GC_DESCRIPTION;
 
 import java.io.File;
 
@@ -70,24 +70,24 @@ import com.vividsolutions.jts.geom.Coordinate;
 @UI(OMSGRASSLEGACYREADER_UI)
 public class OmsGrassLegacyReader extends JGTModel {
 
-    @Description(OMSGRASSLEGACYREADER_file_DESCRIPTION)
+    @Description(OMSGRASSLEGACYREADER_FILE_DESCRIPTION)
     @UI(JGTConstants.FILEIN_UI_HINT)
     @In
     public String file = null;
 
-    @Description(OMSGRASSLEGACYREADER_doActive_DESCRIPTION)
+    @Description(OMSGRASSLEGACYREADER_DOACTIVE_DESCRIPTION)
     @In
     public boolean doActive = true;
 
-    @Description(OMSGRASSLEGACYREADER_inWindow_DESCRIPTION)
+    @Description(OMSGRASSLEGACYREADER_IN_WINDOW_DESCRIPTION)
     @In
     public Window inWindow = null;
 
-    @Description(OMSGRASSLEGACYREADER_outGC_DESCRIPTION)
+    @Description(OMSGRASSLEGACYREADER_OUT_GC_DESCRIPTION)
     @Out
     public GridCoverage2D outGC = null;
 
-    @Description(OMSGRASSLEGACYREADER_geodata_DESCRIPTION)
+    @Description(OMSGRASSLEGACYREADER_GEO_DATA_DESCRIPTION)
     @Out
     public double[][] geodata = null;
 

--- a/jgrassgears/src/main/java/org/jgrasstools/gears/io/rasterwriter/OmsRasterWriter.java
+++ b/jgrassgears/src/main/java/org/jgrasstools/gears/io/rasterwriter/OmsRasterWriter.java
@@ -25,8 +25,8 @@ import static org.jgrasstools.gears.i18n.GearsMessages.OMSRASTERWRITER_LABEL;
 import static org.jgrasstools.gears.i18n.GearsMessages.OMSRASTERWRITER_LICENSE;
 import static org.jgrasstools.gears.i18n.GearsMessages.OMSRASTERWRITER_NAME;
 import static org.jgrasstools.gears.i18n.GearsMessages.OMSRASTERWRITER_STATUS;
-import static org.jgrasstools.gears.i18n.GearsMessages.OMSRASTERWRITER_file_DESCRIPTION;
-import static org.jgrasstools.gears.i18n.GearsMessages.OMSRASTERWRITER_inRaster_DESCRIPTION;
+import static org.jgrasstools.gears.i18n.GearsMessages.OMSRASTERWRITER_FILE_DESCRIPTION;
+import static org.jgrasstools.gears.i18n.GearsMessages.OMSRASTERWRITER_IN_RASTER_DESCRIPTION;
 import static org.jgrasstools.gears.libs.modules.JGTConstants.ESRIGRID;
 import static org.jgrasstools.gears.libs.modules.JGTConstants.GEOTIF;
 import static org.jgrasstools.gears.libs.modules.JGTConstants.GEOTIFF;
@@ -79,11 +79,11 @@ import org.opengis.parameter.ParameterValueGroup;
 @License(OMSRASTERWRITER_LICENSE)
 public class OmsRasterWriter extends JGTModel {
 
-    @Description(OMSRASTERWRITER_inRaster_DESCRIPTION)
+    @Description(OMSRASTERWRITER_IN_RASTER_DESCRIPTION)
     @In
     public GridCoverage2D inRaster = null;
 
-    @Description(OMSRASTERWRITER_file_DESCRIPTION)
+    @Description(OMSRASTERWRITER_FILE_DESCRIPTION)
     @UI(JGTConstants.FILEOUT_UI_HINT)
     @In
     public String file = null;

--- a/jgrassgears/src/main/java/org/jgrasstools/gears/io/timedependent/OmsTimeSeriesIteratorWriter.java
+++ b/jgrassgears/src/main/java/org/jgrasstools/gears/io/timedependent/OmsTimeSeriesIteratorWriter.java
@@ -25,12 +25,12 @@ import static org.jgrasstools.gears.i18n.GearsMessages.OMSTIMESERIESITERATORWRIT
 import static org.jgrasstools.gears.i18n.GearsMessages.OMSTIMESERIESITERATORWRITER_LICENSE;
 import static org.jgrasstools.gears.i18n.GearsMessages.OMSTIMESERIESITERATORWRITER_NAME;
 import static org.jgrasstools.gears.i18n.GearsMessages.OMSTIMESERIESITERATORWRITER_STATUS;
-import static org.jgrasstools.gears.i18n.GearsMessages.OMSTIMESERIESITERATORWRITER_fileNovalue_DESCRIPTION;
-import static org.jgrasstools.gears.i18n.GearsMessages.OMSTIMESERIESITERATORWRITER_file_DESCRIPTION;
-import static org.jgrasstools.gears.i18n.GearsMessages.OMSTIMESERIESITERATORWRITER_inData_DESCRIPTION;
-import static org.jgrasstools.gears.i18n.GearsMessages.OMSTIMESERIESITERATORWRITER_inTablename_DESCRIPTION;
-import static org.jgrasstools.gears.i18n.GearsMessages.OMSTIMESERIESITERATORWRITER_tStart_DESCRIPTION;
-import static org.jgrasstools.gears.i18n.GearsMessages.OMSTIMESERIESITERATORWRITER_tTimestep_DESCRIPTION;
+import static org.jgrasstools.gears.i18n.GearsMessages.OMSTIMESERIESITERATORWRITER_FILE_NOVALUE_DESCRIPTION;
+import static org.jgrasstools.gears.i18n.GearsMessages.OMSTIMESERIESITERATORWRITER_FILE_DESCRIPTION;
+import static org.jgrasstools.gears.i18n.GearsMessages.OMSTIMESERIESITERATORWRITER_IN_DATA_DESCRIPTION;
+import static org.jgrasstools.gears.i18n.GearsMessages.OMSTIMESERIESITERATORWRITER_IN_TABLENAME_DESCRIPTION;
+import static org.jgrasstools.gears.i18n.GearsMessages.OMSTIMESERIESITERATORWRITER_T_START_DESCRIPTION;
+import static org.jgrasstools.gears.i18n.GearsMessages.OMSTIMESERIESITERATORWRITER_T_TIMESTEP_DESCRIPTION;
 
 import java.io.File;
 import java.io.IOException;
@@ -69,28 +69,28 @@ import org.joda.time.format.DateTimeFormatter;
 @License(OMSTIMESERIESITERATORWRITER_LICENSE)
 public class OmsTimeSeriesIteratorWriter extends JGTModel {
 
-    @Description(OMSTIMESERIESITERATORWRITER_file_DESCRIPTION)
+    @Description(OMSTIMESERIESITERATORWRITER_FILE_DESCRIPTION)
     @UI(JGTConstants.FILEOUT_UI_HINT)
     @In
     public String file = null;
 
-    @Description(OMSTIMESERIESITERATORWRITER_inTablename_DESCRIPTION)
+    @Description(OMSTIMESERIESITERATORWRITER_IN_TABLENAME_DESCRIPTION)
     @In
     public String inTablename = "table";
 
-    @Description(OMSTIMESERIESITERATORWRITER_inData_DESCRIPTION)
+    @Description(OMSTIMESERIESITERATORWRITER_IN_DATA_DESCRIPTION)
     @In
     public HashMap<Integer, double[]> inData;
 
-    @Description(OMSTIMESERIESITERATORWRITER_tStart_DESCRIPTION)
+    @Description(OMSTIMESERIESITERATORWRITER_T_START_DESCRIPTION)
     @In
     public String tStart;
 
-    @Description(OMSTIMESERIESITERATORWRITER_tTimestep_DESCRIPTION)
+    @Description(OMSTIMESERIESITERATORWRITER_T_TIMESTEP_DESCRIPTION)
     @In
     public int tTimestep = -1;
 
-    @Description(OMSTIMESERIESITERATORWRITER_fileNovalue_DESCRIPTION)
+    @Description(OMSTIMESERIESITERATORWRITER_FILE_NOVALUE_DESCRIPTION)
     @In
     public String fileNovalue = "-9999.0";
 

--- a/jgrassgears/src/main/java/org/jgrasstools/gears/io/vectorreader/OmsVectorReader.java
+++ b/jgrassgears/src/main/java/org/jgrasstools/gears/io/vectorreader/OmsVectorReader.java
@@ -26,9 +26,9 @@ import static org.jgrasstools.gears.i18n.GearsMessages.OMSVECTORREADER_LABEL;
 import static org.jgrasstools.gears.i18n.GearsMessages.OMSVECTORREADER_LICENSE;
 import static org.jgrasstools.gears.i18n.GearsMessages.OMSVECTORREADER_NAME;
 import static org.jgrasstools.gears.i18n.GearsMessages.OMSVECTORREADER_STATUS;
-import static org.jgrasstools.gears.i18n.GearsMessages.OMSVECTORREADER_file_DESCRIPTION;
-import static org.jgrasstools.gears.i18n.GearsMessages.OMSVECTORREADER_outVector_DESCRIPTION;
-import static org.jgrasstools.gears.i18n.GearsMessages.OMSVECTORREADER_pType_DESCRIPTION;
+import static org.jgrasstools.gears.i18n.GearsMessages.OMSVECTORREADER_FILE_DESCRIPTION;
+import static org.jgrasstools.gears.i18n.GearsMessages.OMSVECTORREADER_OUT_VECTOR_DESCRIPTION;
+import static org.jgrasstools.gears.i18n.GearsMessages.OMSVECTORREADER_P_TYPE_DESCRIPTION;
 
 import java.io.File;
 import java.io.IOException;
@@ -67,17 +67,17 @@ import org.jgrasstools.gears.libs.modules.JGTModel;
 @License(OMSVECTORREADER_LICENSE)
 public class OmsVectorReader extends JGTModel {
 
-    @Description(OMSVECTORREADER_pType_DESCRIPTION)
+    @Description(OMSVECTORREADER_P_TYPE_DESCRIPTION)
     @In
     // currently not used, for future compatibility
     public String pType = null;
 
-    @Description(OMSVECTORREADER_file_DESCRIPTION)
+    @Description(OMSVECTORREADER_FILE_DESCRIPTION)
     @UI(JGTConstants.FILEIN_UI_HINT)
     @In
     public String file = null;
 
-    @Description(OMSVECTORREADER_outVector_DESCRIPTION)
+    @Description(OMSVECTORREADER_OUT_VECTOR_DESCRIPTION)
     @Out
     public SimpleFeatureCollection outVector = null;
 

--- a/jgrassgears/src/main/java/org/jgrasstools/gears/modules/r/linesrasterizer/OmsLinesRasterizer.java
+++ b/jgrassgears/src/main/java/org/jgrasstools/gears/modules/r/linesrasterizer/OmsLinesRasterizer.java
@@ -26,16 +26,16 @@ import static org.jgrasstools.gears.i18n.GearsMessages.OMSLINESRASTERIZER_LABEL;
 import static org.jgrasstools.gears.i18n.GearsMessages.OMSLINESRASTERIZER_LICENSE;
 import static org.jgrasstools.gears.i18n.GearsMessages.OMSLINESRASTERIZER_NAME;
 import static org.jgrasstools.gears.i18n.GearsMessages.OMSLINESRASTERIZER_STATUS;
-import static org.jgrasstools.gears.i18n.GearsMessages.OMSLINESRASTERIZER_fCat_DESCRIPTION;
-import static org.jgrasstools.gears.i18n.GearsMessages.OMSLINESRASTERIZER_inVector_DESCRIPTION;
-import static org.jgrasstools.gears.i18n.GearsMessages.OMSLINESRASTERIZER_outRaster_DESCRIPTION;
-import static org.jgrasstools.gears.i18n.GearsMessages.OMSLINESRASTERIZER_pCat_DESCRIPTION;
-import static org.jgrasstools.gears.i18n.GearsMessages.OMSLINESRASTERIZER_pCols_DESCRIPTION;
-import static org.jgrasstools.gears.i18n.GearsMessages.OMSLINESRASTERIZER_pEast_DESCRIPTION;
-import static org.jgrasstools.gears.i18n.GearsMessages.OMSLINESRASTERIZER_pNorth_DESCRIPTION;
-import static org.jgrasstools.gears.i18n.GearsMessages.OMSLINESRASTERIZER_pRows_DESCRIPTION;
-import static org.jgrasstools.gears.i18n.GearsMessages.OMSLINESRASTERIZER_pSouth_DESCRIPTION;
-import static org.jgrasstools.gears.i18n.GearsMessages.OMSLINESRASTERIZER_pWest_DESCRIPTION;
+import static org.jgrasstools.gears.i18n.GearsMessages.OMSLINESRASTERIZER_F_CAT_DESCRIPTION;
+import static org.jgrasstools.gears.i18n.GearsMessages.OMSLINESRASTERIZER_IN_VECTOR_DESCRIPTION;
+import static org.jgrasstools.gears.i18n.GearsMessages.OMSLINESRASTERIZER_OUT_RASTER_DESCRIPTION;
+import static org.jgrasstools.gears.i18n.GearsMessages.OMSLINESRASTERIZER_P_CAT_DESCRIPTION;
+import static org.jgrasstools.gears.i18n.GearsMessages.OMSLINESRASTERIZER_P_COLS_DESCRIPTION;
+import static org.jgrasstools.gears.i18n.GearsMessages.OMSLINESRASTERIZER_P_EAST_DESCRIPTION;
+import static org.jgrasstools.gears.i18n.GearsMessages.OMSLINESRASTERIZER_P_NORTH_DESCRIPTION;
+import static org.jgrasstools.gears.i18n.GearsMessages.OMSLINESRASTERIZER_P_ROWS_DESCRIPTION;
+import static org.jgrasstools.gears.i18n.GearsMessages.OMSLINESRASTERIZER_P_SOUTH_DESCRIPTION;
+import static org.jgrasstools.gears.i18n.GearsMessages.OMSLINESRASTERIZER_P_WEST_DESCRIPTION;
 import static org.jgrasstools.gears.utils.coverage.CoverageUtilities.gridGeometryFromRegionValues;
 import static org.jgrasstools.gears.utils.geometry.GeometryUtilities.getGeometryType;
 
@@ -91,49 +91,49 @@ import com.vividsolutions.jts.geom.LineString;
 @License(OMSLINESRASTERIZER_LICENSE)
 public class OmsLinesRasterizer extends JGTModel {
 
-    @Description(OMSLINESRASTERIZER_inVector_DESCRIPTION)
+    @Description(OMSLINESRASTERIZER_IN_VECTOR_DESCRIPTION)
     @In
     public SimpleFeatureCollection inVector = null;
 
-    @Description(OMSLINESRASTERIZER_fCat_DESCRIPTION)
+    @Description(OMSLINESRASTERIZER_F_CAT_DESCRIPTION)
     @In
     public String fCat;
 
-    @Description(OMSLINESRASTERIZER_pCat_DESCRIPTION)
+    @Description(OMSLINESRASTERIZER_P_CAT_DESCRIPTION)
     @In
     public double pCat = 1.0;
 
-    @Description(OMSLINESRASTERIZER_pNorth_DESCRIPTION)
+    @Description(OMSLINESRASTERIZER_P_NORTH_DESCRIPTION)
     @UI(JGTConstants.PROCESS_NORTH_UI_HINT)
     @In
     public Double pNorth = null;
 
-    @Description(OMSLINESRASTERIZER_pSouth_DESCRIPTION)
+    @Description(OMSLINESRASTERIZER_P_SOUTH_DESCRIPTION)
     @UI(JGTConstants.PROCESS_SOUTH_UI_HINT)
     @In
     public Double pSouth = null;
 
-    @Description(OMSLINESRASTERIZER_pWest_DESCRIPTION)
+    @Description(OMSLINESRASTERIZER_P_WEST_DESCRIPTION)
     @UI(JGTConstants.PROCESS_WEST_UI_HINT)
     @In
     public Double pWest = null;
 
-    @Description(OMSLINESRASTERIZER_pEast_DESCRIPTION)
+    @Description(OMSLINESRASTERIZER_P_EAST_DESCRIPTION)
     @UI(JGTConstants.PROCESS_EAST_UI_HINT)
     @In
     public Double pEast = null;
 
-    @Description(OMSLINESRASTERIZER_pRows_DESCRIPTION)
+    @Description(OMSLINESRASTERIZER_P_ROWS_DESCRIPTION)
     @UI(JGTConstants.PROCESS_ROWS_UI_HINT)
     @In
     public Integer pRows = null;
 
-    @Description(OMSLINESRASTERIZER_pCols_DESCRIPTION)
+    @Description(OMSLINESRASTERIZER_P_COLS_DESCRIPTION)
     @UI(JGTConstants.PROCESS_COLS_UI_HINT)
     @In
     public Integer pCols = null;
 
-    @Description(OMSLINESRASTERIZER_outRaster_DESCRIPTION)
+    @Description(OMSLINESRASTERIZER_OUT_RASTER_DESCRIPTION)
     @Out
     public GridCoverage2D outRaster;
 

--- a/jgrassgears/src/main/java/org/jgrasstools/gears/modules/r/rastervectorintersection/OmsRasterVectorIntersector.java
+++ b/jgrassgears/src/main/java/org/jgrasstools/gears/modules/r/rastervectorintersection/OmsRasterVectorIntersector.java
@@ -26,10 +26,10 @@ import static org.jgrasstools.gears.i18n.GearsMessages.OMSRASTERVECTORINTERSECTO
 import static org.jgrasstools.gears.i18n.GearsMessages.OMSRASTERVECTORINTERSECTOR_LICENSE;
 import static org.jgrasstools.gears.i18n.GearsMessages.OMSRASTERVECTORINTERSECTOR_NAME;
 import static org.jgrasstools.gears.i18n.GearsMessages.OMSRASTERVECTORINTERSECTOR_STATUS;
-import static org.jgrasstools.gears.i18n.GearsMessages.OMSRASTERVECTORINTERSECTOR_doInverse_DESCRIPTION;
-import static org.jgrasstools.gears.i18n.GearsMessages.OMSRASTERVECTORINTERSECTOR_inRaster_DESCRIPTION;
-import static org.jgrasstools.gears.i18n.GearsMessages.OMSRASTERVECTORINTERSECTOR_inVector_DESCRIPTION;
-import static org.jgrasstools.gears.i18n.GearsMessages.OMSRASTERVECTORINTERSECTOR_outRaster_DESCRIPTION;
+import static org.jgrasstools.gears.i18n.GearsMessages.OMSRASTERVECTORINTERSECTOR_DO_INVERSE_DESCRIPTION;
+import static org.jgrasstools.gears.i18n.GearsMessages.OMSRASTERVECTORINTERSECTOR_IN_RASTER_DESCRIPTION;
+import static org.jgrasstools.gears.i18n.GearsMessages.OMSRASTERVECTORINTERSECTOR_IN_VECTOR_DESCRIPTION;
+import static org.jgrasstools.gears.i18n.GearsMessages.OMSRASTERVECTORINTERSECTOR_OUT_RASTER_DESCRIPTION;
 import static org.jgrasstools.gears.utils.geometry.GeometryUtilities.getGeometryType;
 import oms3.annotations.Author;
 import oms3.annotations.Description;
@@ -64,19 +64,19 @@ import org.opengis.feature.type.GeometryType;
 @License(OMSRASTERVECTORINTERSECTOR_LICENSE)
 public class OmsRasterVectorIntersector extends JGTModel {
 
-    @Description(OMSRASTERVECTORINTERSECTOR_inVector_DESCRIPTION)
+    @Description(OMSRASTERVECTORINTERSECTOR_IN_VECTOR_DESCRIPTION)
     @In
     public SimpleFeatureCollection inVector = null;
 
-    @Description(OMSRASTERVECTORINTERSECTOR_inRaster_DESCRIPTION)
+    @Description(OMSRASTERVECTORINTERSECTOR_IN_RASTER_DESCRIPTION)
     @In
     public GridCoverage2D inRaster;
 
-    @Description(OMSRASTERVECTORINTERSECTOR_doInverse_DESCRIPTION)
+    @Description(OMSRASTERVECTORINTERSECTOR_DO_INVERSE_DESCRIPTION)
     @In
     public boolean doInverse = false;
 
-    @Description(OMSRASTERVECTORINTERSECTOR_outRaster_DESCRIPTION)
+    @Description(OMSRASTERVECTORINTERSECTOR_OUT_RASTER_DESCRIPTION)
     @Out
     public GridCoverage2D outRaster;
 

--- a/jgrassgears/src/main/java/org/jgrasstools/gears/modules/r/windowsampler/OmsWindowSampler.java
+++ b/jgrassgears/src/main/java/org/jgrasstools/gears/modules/r/windowsampler/OmsWindowSampler.java
@@ -29,13 +29,13 @@ import static org.jgrasstools.gears.i18n.GearsMessages.OMSWINDOWSAMPLER_LABEL;
 import static org.jgrasstools.gears.i18n.GearsMessages.OMSWINDOWSAMPLER_LICENSE;
 import static org.jgrasstools.gears.i18n.GearsMessages.OMSWINDOWSAMPLER_NAME;
 import static org.jgrasstools.gears.i18n.GearsMessages.OMSWINDOWSAMPLER_STATUS;
-import static org.jgrasstools.gears.i18n.GearsMessages.OMSWINDOWSAMPLER_inGeodata_DESCRIPTION;
-import static org.jgrasstools.gears.i18n.GearsMessages.OMSWINDOWSAMPLER_outGeodata_DESCRIPTION;
-import static org.jgrasstools.gears.i18n.GearsMessages.OMSWINDOWSAMPLER_pCols_DESCRIPTION;
-import static org.jgrasstools.gears.i18n.GearsMessages.OMSWINDOWSAMPLER_pMode_DESCRIPTION;
-import static org.jgrasstools.gears.i18n.GearsMessages.OMSWINDOWSAMPLER_pRows_DESCRIPTION;
-import static org.jgrasstools.gears.i18n.GearsMessages.OMSWINDOWSAMPLER_pXstep_DESCRIPTION;
-import static org.jgrasstools.gears.i18n.GearsMessages.OMSWINDOWSAMPLER_pYstep_DESCRIPTION;
+import static org.jgrasstools.gears.i18n.GearsMessages.OMSWINDOWSAMPLER_IN_GEODATA_DESCRIPTION;
+import static org.jgrasstools.gears.i18n.GearsMessages.OMSWINDOWSAMPLER_OUT_GEODATA_DESCRIPTION;
+import static org.jgrasstools.gears.i18n.GearsMessages.OMSWINDOWSAMPLER_P_COLS_DESCRIPTION;
+import static org.jgrasstools.gears.i18n.GearsMessages.OMSWINDOWSAMPLER_P_MODE_DESCRIPTION;
+import static org.jgrasstools.gears.i18n.GearsMessages.OMSWINDOWSAMPLER_P_ROWS_DESCRIPTION;
+import static org.jgrasstools.gears.i18n.GearsMessages.OMSWINDOWSAMPLER_P_X_STEP_DESCRIPTION;
+import static org.jgrasstools.gears.i18n.GearsMessages.OMSWINDOWSAMPLER_P_Y_STEP_DESCRIPTION;
 import static org.jgrasstools.gears.libs.modules.JGTConstants.isNovalue;
 
 import java.awt.Dimension;
@@ -72,31 +72,31 @@ import org.jgrasstools.gears.utils.coverage.CoverageUtilities;
 @License(OMSWINDOWSAMPLER_LICENSE)
 public class OmsWindowSampler extends JGTModel {
 
-    @Description(OMSWINDOWSAMPLER_inGeodata_DESCRIPTION)
+    @Description(OMSWINDOWSAMPLER_IN_GEODATA_DESCRIPTION)
     @In
     public GridCoverage2D inGeodata;
 
-    @Description(OMSWINDOWSAMPLER_pMode_DESCRIPTION)
+    @Description(OMSWINDOWSAMPLER_P_MODE_DESCRIPTION)
     @In
     public int pMode = 0;
 
-    @Description(OMSWINDOWSAMPLER_pRows_DESCRIPTION)
+    @Description(OMSWINDOWSAMPLER_P_ROWS_DESCRIPTION)
     @In
     public int pRows = 3;
 
-    @Description(OMSWINDOWSAMPLER_pCols_DESCRIPTION)
+    @Description(OMSWINDOWSAMPLER_P_COLS_DESCRIPTION)
     @In
     public int pCols = 3;
 
-    @Description(OMSWINDOWSAMPLER_pXstep_DESCRIPTION)
+    @Description(OMSWINDOWSAMPLER_P_X_STEP_DESCRIPTION)
     @In
     public Integer pXstep;
 
-    @Description(OMSWINDOWSAMPLER_pYstep_DESCRIPTION)
+    @Description(OMSWINDOWSAMPLER_P_Y_STEP_DESCRIPTION)
     @In
     public Integer pYstep;
 
-    @Description(OMSWINDOWSAMPLER_outGeodata_DESCRIPTION)
+    @Description(OMSWINDOWSAMPLER_OUT_GEODATA_DESCRIPTION)
     @Out
     public GridCoverage2D outGeodata;
 

--- a/jgrassgears/src/main/java/org/jgrasstools/gears/modules/v/contourlabels/OmsContourLinesLabeler.java
+++ b/jgrassgears/src/main/java/org/jgrasstools/gears/modules/v/contourlabels/OmsContourLinesLabeler.java
@@ -27,11 +27,11 @@ import static org.jgrasstools.gears.i18n.GearsMessages.OMSCONTOURLINESLABELER_LA
 import static org.jgrasstools.gears.i18n.GearsMessages.OMSCONTOURLINESLABELER_LICENSE;
 import static org.jgrasstools.gears.i18n.GearsMessages.OMSCONTOURLINESLABELER_NAME;
 import static org.jgrasstools.gears.i18n.GearsMessages.OMSCONTOURLINESLABELER_STATUS;
-import static org.jgrasstools.gears.i18n.GearsMessages.OMSCONTOURLINESLABELER_buffer_DESCRIPTION;
-import static org.jgrasstools.gears.i18n.GearsMessages.OMSCONTOURLINESLABELER_fElevation_DESCRIPTION;
-import static org.jgrasstools.gears.i18n.GearsMessages.OMSCONTOURLINESLABELER_inContour_DESCRIPTION;
-import static org.jgrasstools.gears.i18n.GearsMessages.OMSCONTOURLINESLABELER_inLines_DESCRIPTION;
-import static org.jgrasstools.gears.i18n.GearsMessages.OMSCONTOURLINESLABELER_outPoints_DESCRIPTION;
+import static org.jgrasstools.gears.i18n.GearsMessages.OMSCONTOURLINESLABELER_BUFFER_DESCRIPTION;
+import static org.jgrasstools.gears.i18n.GearsMessages.OMSCONTOURLINESLABELER_F_ELEVATION_DESCRIPTION;
+import static org.jgrasstools.gears.i18n.GearsMessages.OMSCONTOURLINESLABELER_IN_CONTOUR_DESCRIPTION;
+import static org.jgrasstools.gears.i18n.GearsMessages.OMSCONTOURLINESLABELER_INLINES_DESCRIPTION;
+import static org.jgrasstools.gears.i18n.GearsMessages.OMSCONTOURLINESLABELER_OUTPOINTS_DESCRIPTION;
 import oms3.annotations.Author;
 import oms3.annotations.Description;
 import oms3.annotations.Documentation;
@@ -74,23 +74,23 @@ import com.vividsolutions.jts.geom.Point;
 @License(OMSCONTOURLINESLABELER_LICENSE)
 public class OmsContourLinesLabeler extends JGTModel {
 
-    @Description(OMSCONTOURLINESLABELER_inContour_DESCRIPTION)
+    @Description(OMSCONTOURLINESLABELER_IN_CONTOUR_DESCRIPTION)
     @In
     public SimpleFeatureCollection inContour;
 
-    @Description(OMSCONTOURLINESLABELER_fElevation_DESCRIPTION)
+    @Description(OMSCONTOURLINESLABELER_F_ELEVATION_DESCRIPTION)
     @In
     public String fElevation;
 
-    @Description(OMSCONTOURLINESLABELER_inLines_DESCRIPTION)
+    @Description(OMSCONTOURLINESLABELER_INLINES_DESCRIPTION)
     @In
     public SimpleFeatureCollection inLines;
 
-    @Description(OMSCONTOURLINESLABELER_buffer_DESCRIPTION)
+    @Description(OMSCONTOURLINESLABELER_BUFFER_DESCRIPTION)
     @In
     public double buffer;
 
-    @Description(OMSCONTOURLINESLABELER_outPoints_DESCRIPTION)
+    @Description(OMSCONTOURLINESLABELER_OUTPOINTS_DESCRIPTION)
     @Out
     public SimpleFeatureCollection outPoints = null;
 

--- a/jgrassgears/src/main/java/org/jgrasstools/gears/modules/v/smoothing/OmsLineSmootherMcMaster.java
+++ b/jgrassgears/src/main/java/org/jgrasstools/gears/modules/v/smoothing/OmsLineSmootherMcMaster.java
@@ -26,13 +26,13 @@ import static org.jgrasstools.gears.i18n.GearsMessages.OMSLINESMOOTHERMCMASTER_L
 import static org.jgrasstools.gears.i18n.GearsMessages.OMSLINESMOOTHERMCMASTER_LICENSE;
 import static org.jgrasstools.gears.i18n.GearsMessages.OMSLINESMOOTHERMCMASTER_NAME;
 import static org.jgrasstools.gears.i18n.GearsMessages.OMSLINESMOOTHERMCMASTER_STATUS;
-import static org.jgrasstools.gears.i18n.GearsMessages.OMSLINESMOOTHERMCMASTER_inVector_DESCRIPTION;
-import static org.jgrasstools.gears.i18n.GearsMessages.OMSLINESMOOTHERMCMASTER_outVector_DESCRIPTION;
-import static org.jgrasstools.gears.i18n.GearsMessages.OMSLINESMOOTHERMCMASTER_pDensify_DESCRIPTION;
-import static org.jgrasstools.gears.i18n.GearsMessages.OMSLINESMOOTHERMCMASTER_pLimit_DESCRIPTION;
-import static org.jgrasstools.gears.i18n.GearsMessages.OMSLINESMOOTHERMCMASTER_pLookahead_DESCRIPTION;
-import static org.jgrasstools.gears.i18n.GearsMessages.OMSLINESMOOTHERMCMASTER_pSimplify_DESCRIPTION;
-import static org.jgrasstools.gears.i18n.GearsMessages.OMSLINESMOOTHERMCMASTER_pSlide_DESCRIPTION;
+import static org.jgrasstools.gears.i18n.GearsMessages.OMSLINESMOOTHERMCMASTER_IN_VECTOR_DESCRIPTION;
+import static org.jgrasstools.gears.i18n.GearsMessages.OMSLINESMOOTHERMCMASTER_OUT_VECTOR_DESCRIPTION;
+import static org.jgrasstools.gears.i18n.GearsMessages.OMSLINESMOOTHERMCMASTER_P_DENSIFY_DESCRIPTION;
+import static org.jgrasstools.gears.i18n.GearsMessages.OMSLINESMOOTHERMCMASTER_P_LIMIT_DESCRIPTION;
+import static org.jgrasstools.gears.i18n.GearsMessages.OMSLINESMOOTHERMCMASTER_P_LOOK_AHEAD_DESCRIPTION;
+import static org.jgrasstools.gears.i18n.GearsMessages.OMSLINESMOOTHERMCMASTER_P_SIMPLIFY_DESCRIPTION;
+import static org.jgrasstools.gears.i18n.GearsMessages.OMSLINESMOOTHERMCMASTER_P_SLIDE_DESCRIPTION;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -79,31 +79,31 @@ import com.vividsolutions.jts.simplify.TopologyPreservingSimplifier;
 @License(OMSLINESMOOTHERMCMASTER_LICENSE)
 public class OmsLineSmootherMcMaster extends JGTModel {
 
-    @Description(OMSLINESMOOTHERMCMASTER_inVector_DESCRIPTION)
+    @Description(OMSLINESMOOTHERMCMASTER_IN_VECTOR_DESCRIPTION)
     @In
     public SimpleFeatureCollection inVector;
 
-    @Description(OMSLINESMOOTHERMCMASTER_pLookahead_DESCRIPTION)
+    @Description(OMSLINESMOOTHERMCMASTER_P_LOOK_AHEAD_DESCRIPTION)
     @In
     public int pLookahead = 7;
 
-    @Description(OMSLINESMOOTHERMCMASTER_pLimit_DESCRIPTION)
+    @Description(OMSLINESMOOTHERMCMASTER_P_LIMIT_DESCRIPTION)
     @In
     public int pLimit = 0;
 
-    @Description(OMSLINESMOOTHERMCMASTER_pSlide_DESCRIPTION)
+    @Description(OMSLINESMOOTHERMCMASTER_P_SLIDE_DESCRIPTION)
     @In
     public double pSlide = 0.9;
 
-    @Description(OMSLINESMOOTHERMCMASTER_pDensify_DESCRIPTION)
+    @Description(OMSLINESMOOTHERMCMASTER_P_DENSIFY_DESCRIPTION)
     @In
     public Double pDensify = null;
 
-    @Description(OMSLINESMOOTHERMCMASTER_pSimplify_DESCRIPTION)
+    @Description(OMSLINESMOOTHERMCMASTER_P_SIMPLIFY_DESCRIPTION)
     @In
     public Double pSimplify = null;
 
-    @Description(OMSLINESMOOTHERMCMASTER_outVector_DESCRIPTION)
+    @Description(OMSLINESMOOTHERMCMASTER_OUT_VECTOR_DESCRIPTION)
     @Out
     public SimpleFeatureCollection outVector;
 

--- a/jgrassgears/src/main/java/org/jgrasstools/gears/modules/v/vectorconverter/OmsVectorConverter.java
+++ b/jgrassgears/src/main/java/org/jgrasstools/gears/modules/v/vectorconverter/OmsVectorConverter.java
@@ -28,8 +28,8 @@ import static org.jgrasstools.gears.i18n.GearsMessages.OMSVECTORCONVERTER_LICENS
 import static org.jgrasstools.gears.i18n.GearsMessages.OMSVECTORCONVERTER_NAME;
 import static org.jgrasstools.gears.i18n.GearsMessages.OMSVECTORCONVERTER_STATUS;
 import static org.jgrasstools.gears.i18n.GearsMessages.OMSVECTORCONVERTER_UI;
-import static org.jgrasstools.gears.i18n.GearsMessages.OMSVECTORCONVERTER_inGeodata_DESCRIPTION;
-import static org.jgrasstools.gears.i18n.GearsMessages.OMSVECTORCONVERTER_outGeodata_DESCRIPTION;
+import static org.jgrasstools.gears.i18n.GearsMessages.OMSVECTORCONVERTER_IN_GEODATA_DESCRIPTION;
+import static org.jgrasstools.gears.i18n.GearsMessages.OMSVECTORCONVERTER_OUT_GEODATA_DESCRIPTION;
 import oms3.annotations.Author;
 import oms3.annotations.Description;
 import oms3.annotations.Documentation;
@@ -57,11 +57,11 @@ import org.jgrasstools.gears.libs.modules.JGTModel;
 @UI(OMSVECTORCONVERTER_UI)
 public class OmsVectorConverter extends JGTModel {
 
-    @Description(OMSVECTORCONVERTER_inGeodata_DESCRIPTION)
+    @Description(OMSVECTORCONVERTER_IN_GEODATA_DESCRIPTION)
     @In
     public SimpleFeatureCollection inGeodata;
 
-    @Description(OMSVECTORCONVERTER_outGeodata_DESCRIPTION)
+    @Description(OMSVECTORCONVERTER_OUT_GEODATA_DESCRIPTION)
     @Out
     public SimpleFeatureCollection outGeodata;
 

--- a/jgrassgears/src/main/java/org/jgrasstools/gears/modules/v/vectorize/OmsPointsVectorizer.java
+++ b/jgrassgears/src/main/java/org/jgrasstools/gears/modules/v/vectorize/OmsPointsVectorizer.java
@@ -26,9 +26,9 @@ import static org.jgrasstools.gears.i18n.GearsMessages.OMSPOINTSVECTORIZER_LABEL
 import static org.jgrasstools.gears.i18n.GearsMessages.OMSPOINTSVECTORIZER_LICENSE;
 import static org.jgrasstools.gears.i18n.GearsMessages.OMSPOINTSVECTORIZER_NAME;
 import static org.jgrasstools.gears.i18n.GearsMessages.OMSPOINTSVECTORIZER_STATUS;
-import static org.jgrasstools.gears.i18n.GearsMessages.OMSPOINTSVECTORIZER_fDefault_DESCRIPTION;
-import static org.jgrasstools.gears.i18n.GearsMessages.OMSPOINTSVECTORIZER_inRaster_DESCRIPTION;
-import static org.jgrasstools.gears.i18n.GearsMessages.OMSPOINTSVECTORIZER_outVector_DESCRIPTION;
+import static org.jgrasstools.gears.i18n.GearsMessages.OMSPOINTSVECTORIZER_F_DEFAULT_DESCRIPTION;
+import static org.jgrasstools.gears.i18n.GearsMessages.OMSPOINTSVECTORIZER_IN_RASTER_DESCRIPTION;
+import static org.jgrasstools.gears.i18n.GearsMessages.OMSPOINTSVECTORIZER_OUT_VECTOR_DESCRIPTION;
 import static org.jgrasstools.gears.libs.modules.JGTConstants.isNovalue;
 import static org.jgrasstools.gears.utils.coverage.CoverageUtilities.getRegionParamsFromGridCoverage;
 
@@ -74,15 +74,15 @@ import com.vividsolutions.jts.geom.Point;
 @License(OMSPOINTSVECTORIZER_LICENSE)
 public class OmsPointsVectorizer extends JGTModel {
 
-    @Description(OMSPOINTSVECTORIZER_inRaster_DESCRIPTION)
+    @Description(OMSPOINTSVECTORIZER_IN_RASTER_DESCRIPTION)
     @In
     public GridCoverage2D inRaster;
 
-    @Description(OMSPOINTSVECTORIZER_fDefault_DESCRIPTION)
+    @Description(OMSPOINTSVECTORIZER_F_DEFAULT_DESCRIPTION)
     @In
     public String fDefault = "value";
 
-    @Description(OMSPOINTSVECTORIZER_outVector_DESCRIPTION)
+    @Description(OMSPOINTSVECTORIZER_OUT_VECTOR_DESCRIPTION)
     @Out
     public SimpleFeatureCollection outVector = null;
 

--- a/jgrassgears/src/main/java/org/jgrasstools/gears/ui/OmsMatrixCharter.java
+++ b/jgrassgears/src/main/java/org/jgrasstools/gears/ui/OmsMatrixCharter.java
@@ -27,24 +27,24 @@ import static org.jgrasstools.gears.i18n.GearsMessages.OMSMATRIXCHARTER_LICENSE;
 import static org.jgrasstools.gears.i18n.GearsMessages.OMSMATRIXCHARTER_NAME;
 import static org.jgrasstools.gears.i18n.GearsMessages.OMSMATRIXCHARTER_STATUS;
 import static org.jgrasstools.gears.i18n.GearsMessages.OMSMATRIXCHARTER_UI;
-import static org.jgrasstools.gears.i18n.GearsMessages.OMSMATRIXCHARTER_doChart_DESCRIPTION;
-import static org.jgrasstools.gears.i18n.GearsMessages.OMSMATRIXCHARTER_doCumulate_DESCRIPTION;
-import static org.jgrasstools.gears.i18n.GearsMessages.OMSMATRIXCHARTER_doDump_DESCRIPTION;
-import static org.jgrasstools.gears.i18n.GearsMessages.OMSMATRIXCHARTER_doLegend_DESCRIPTION;
-import static org.jgrasstools.gears.i18n.GearsMessages.OMSMATRIXCHARTER_doNormalize_DESCRIPTION;
-import static org.jgrasstools.gears.i18n.GearsMessages.OMSMATRIXCHARTER_doPoints_DESCRIPTION;
-import static org.jgrasstools.gears.i18n.GearsMessages.OMSMATRIXCHARTER_inChartPath_DESCRIPTION;
-import static org.jgrasstools.gears.i18n.GearsMessages.OMSMATRIXCHARTER_inColors_DESCRIPTION;
-import static org.jgrasstools.gears.i18n.GearsMessages.OMSMATRIXCHARTER_inData_DESCRIPTION;
-import static org.jgrasstools.gears.i18n.GearsMessages.OMSMATRIXCHARTER_inFormats_DESCRIPTION;
-import static org.jgrasstools.gears.i18n.GearsMessages.OMSMATRIXCHARTER_inLabels_DESCRIPTION;
-import static org.jgrasstools.gears.i18n.GearsMessages.OMSMATRIXCHARTER_inSeries_DESCRIPTION;
-import static org.jgrasstools.gears.i18n.GearsMessages.OMSMATRIXCHARTER_inSubTitle_DESCRIPTION;
-import static org.jgrasstools.gears.i18n.GearsMessages.OMSMATRIXCHARTER_inTitle_DESCRIPTION;
-import static org.jgrasstools.gears.i18n.GearsMessages.OMSMATRIXCHARTER_inTypes_DESCRIPTION;
-import static org.jgrasstools.gears.i18n.GearsMessages.OMSMATRIXCHARTER_pHeight_DESCRIPTION;
-import static org.jgrasstools.gears.i18n.GearsMessages.OMSMATRIXCHARTER_pType_DESCRIPTION;
-import static org.jgrasstools.gears.i18n.GearsMessages.OMSMATRIXCHARTER_pWidth_DESCRIPTION;
+import static org.jgrasstools.gears.i18n.GearsMessages.OMSMATRIXCHARTER_DO_CHART_DESCRIPTION;
+import static org.jgrasstools.gears.i18n.GearsMessages.OMSMATRIXCHARTER_DO_CUMULATE_DESCRIPTION;
+import static org.jgrasstools.gears.i18n.GearsMessages.OMSMATRIXCHARTER_DO_DUMP_DESCRIPTION;
+import static org.jgrasstools.gears.i18n.GearsMessages.OMSMATRIXCHARTER_DO_LEGEND_DESCRIPTION;
+import static org.jgrasstools.gears.i18n.GearsMessages.OMSMATRIXCHARTER_DO_NORMALIZE_DESCRIPTION;
+import static org.jgrasstools.gears.i18n.GearsMessages.OMSMATRIXCHARTER_DO_POINTS_DESCRIPTION;
+import static org.jgrasstools.gears.i18n.GearsMessages.OMSMATRIXCHARTER_IN_CHARTPATH_DESCRIPTION;
+import static org.jgrasstools.gears.i18n.GearsMessages.OMSMATRIXCHARTER_IN_COLORS_DESCRIPTION;
+import static org.jgrasstools.gears.i18n.GearsMessages.OMSMATRIXCHARTER_IN_DATA_DESCRIPTION;
+import static org.jgrasstools.gears.i18n.GearsMessages.OMSMATRIXCHARTER_IN_FORMATS_DESCRIPTION;
+import static org.jgrasstools.gears.i18n.GearsMessages.OMSMATRIXCHARTER_IN_LABELS_DESCRIPTION;
+import static org.jgrasstools.gears.i18n.GearsMessages.OMSMATRIXCHARTER_IN_SERIES_DESCRIPTION;
+import static org.jgrasstools.gears.i18n.GearsMessages.OMSMATRIXCHARTER_IN_SUBTITLE_DESCRIPTION;
+import static org.jgrasstools.gears.i18n.GearsMessages.OMSMATRIXCHARTER_IN_TITLE_DESCRIPTION;
+import static org.jgrasstools.gears.i18n.GearsMessages.OMSMATRIXCHARTER_IN_TYPES_DESCRIPTION;
+import static org.jgrasstools.gears.i18n.GearsMessages.OMSMATRIXCHARTER_P_HEIGHT_DESCRIPTION;
+import static org.jgrasstools.gears.i18n.GearsMessages.OMSMATRIXCHARTER_P_TYPE_DESCRIPTION;
+import static org.jgrasstools.gears.i18n.GearsMessages.OMSMATRIXCHARTER_P_WIDTH_DESCRIPTION;
 
 import java.awt.Color;
 import java.awt.Dimension;
@@ -99,7 +99,7 @@ import org.jgrasstools.gears.utils.files.FileUtilities;
 @UI(OMSMATRIXCHARTER_UI)
 public class OmsMatrixCharter extends JGTModel {
 
-    @Description(OMSMATRIXCHARTER_inData_DESCRIPTION)
+    @Description(OMSMATRIXCHARTER_IN_DATA_DESCRIPTION)
     @In
     public double[][] inData;
 
@@ -107,59 +107,59 @@ public class OmsMatrixCharter extends JGTModel {
     @In
     public List<double[][]> inDataXY;
 
-    @Description(OMSMATRIXCHARTER_inTitle_DESCRIPTION)
+    @Description(OMSMATRIXCHARTER_IN_TITLE_DESCRIPTION)
     @In
     public String inTitle;
 
-    @Description(OMSMATRIXCHARTER_inSubTitle_DESCRIPTION)
+    @Description(OMSMATRIXCHARTER_IN_SUBTITLE_DESCRIPTION)
     @In
     public String inSubTitle;
 
-    @Description(OMSMATRIXCHARTER_inSeries_DESCRIPTION)
+    @Description(OMSMATRIXCHARTER_IN_SERIES_DESCRIPTION)
     @In
     public String[] inSeries;
 
-    @Description(OMSMATRIXCHARTER_inColors_DESCRIPTION)
+    @Description(OMSMATRIXCHARTER_IN_COLORS_DESCRIPTION)
     @In
     public String inColors;
 
-    @Description(OMSMATRIXCHARTER_inLabels_DESCRIPTION)
+    @Description(OMSMATRIXCHARTER_IN_LABELS_DESCRIPTION)
     @In
     public String[] inLabels;
 
-    @Description(OMSMATRIXCHARTER_inFormats_DESCRIPTION)
+    @Description(OMSMATRIXCHARTER_IN_FORMATS_DESCRIPTION)
     @In
     public String[] inFormats;
 
-    @Description(OMSMATRIXCHARTER_inTypes_DESCRIPTION)
+    @Description(OMSMATRIXCHARTER_IN_TYPES_DESCRIPTION)
     @In
     public String[] inTypes;
 
-    @Description(OMSMATRIXCHARTER_pType_DESCRIPTION)
+    @Description(OMSMATRIXCHARTER_P_TYPE_DESCRIPTION)
     @In
     public int pType = 0;
 
-    @Description(OMSMATRIXCHARTER_doChart_DESCRIPTION)
+    @Description(OMSMATRIXCHARTER_DO_CHART_DESCRIPTION)
     @In
     public boolean doChart;
 
-    @Description(OMSMATRIXCHARTER_doDump_DESCRIPTION)
+    @Description(OMSMATRIXCHARTER_DO_DUMP_DESCRIPTION)
     @In
     public boolean doDump;
 
-    @Description(OMSMATRIXCHARTER_doLegend_DESCRIPTION)
+    @Description(OMSMATRIXCHARTER_DO_LEGEND_DESCRIPTION)
     @In
     public boolean doLegend;
 
-    @Description(OMSMATRIXCHARTER_doPoints_DESCRIPTION)
+    @Description(OMSMATRIXCHARTER_DO_POINTS_DESCRIPTION)
     @In
     public boolean doPoints;
 
-    @Description(OMSMATRIXCHARTER_doCumulate_DESCRIPTION)
+    @Description(OMSMATRIXCHARTER_DO_CUMULATE_DESCRIPTION)
     @In
     public boolean doCumulate;
 
-    @Description(OMSMATRIXCHARTER_doNormalize_DESCRIPTION)
+    @Description(OMSMATRIXCHARTER_DO_NORMALIZE_DESCRIPTION)
     @In
     public boolean doNormalize;
 
@@ -167,15 +167,15 @@ public class OmsMatrixCharter extends JGTModel {
     @In
     public boolean doHorizontal;
 
-    @Description(OMSMATRIXCHARTER_pWidth_DESCRIPTION)
+    @Description(OMSMATRIXCHARTER_P_WIDTH_DESCRIPTION)
     @In
     public int pWidth = 800;
 
-    @Description(OMSMATRIXCHARTER_pHeight_DESCRIPTION)
+    @Description(OMSMATRIXCHARTER_P_HEIGHT_DESCRIPTION)
     @In
     public int pHeight = 600;
 
-    @Description(OMSMATRIXCHARTER_inChartPath_DESCRIPTION)
+    @Description(OMSMATRIXCHARTER_IN_CHARTPATH_DESCRIPTION)
     @In
     public String inChartPath;
 

--- a/modules/src/main/java/org/jgrasstools/modules/Geopaparazzi3Converter.java
+++ b/modules/src/main/java/org/jgrasstools/modules/Geopaparazzi3Converter.java
@@ -35,28 +35,28 @@ import static org.jgrasstools.gears.i18n.GearsMessages.*;
 @License(OMSHYDRO_LICENSE)
 public class Geopaparazzi3Converter extends JGTModel {
 
-    @Description(OMSGEOPAPARAZZICONVERTER_inGeopaparazzi_DESCRIPTION)
+    @Description(OMSGEOPAPARAZZICONVERTER_IN_GEOPAPARAZZI_DESCRIPTION)
     @UI(JGTConstants.FOLDERIN_UI_HINT)
     @In
     public String inGeopaparazzi = null;
 
-    @Description(OMSGEOPAPARAZZICONVERTER_doNotes_DESCRIPTION)
+    @Description(OMSGEOPAPARAZZICONVERTER_DO_NOTES_DESCRIPTION)
     @In
     public boolean doNotes = true;
 
-    @Description(OMSGEOPAPARAZZICONVERTER_doLoglines_DESCRIPTION)
+    @Description(OMSGEOPAPARAZZICONVERTER_DO_LOG_LINES_DESCRIPTION)
     @In
     public boolean doLoglines = true;
 
-    @Description(OMSGEOPAPARAZZICONVERTER_doLogpoints_DESCRIPTION)
+    @Description(OMSGEOPAPARAZZICONVERTER_DO_LOG_POINTS_DESCRIPTION)
     @In
     public boolean doLogpoints = false;
 
-    @Description(OMSGEOPAPARAZZICONVERTER_doMedia_DESCRIPTION)
+    @Description(OMSGEOPAPARAZZICONVERTER_DO_MEDIA_DESCRIPTION)
     @In
     public boolean doMedia = true;
 
-    @Description(OMSGEOPAPARAZZICONVERTER_outData_DESCRIPTION)
+    @Description(OMSGEOPAPARAZZICONVERTER_OUTDATA_DESCRIPTION)
     @UI(JGTConstants.FOLDEROUT_UI_HINT)
     @In
     public String outData = null;

--- a/modules/src/main/java/org/jgrasstools/modules/Geopaparazzi4Converter.java
+++ b/modules/src/main/java/org/jgrasstools/modules/Geopaparazzi4Converter.java
@@ -57,23 +57,23 @@ public class Geopaparazzi4Converter extends JGTModel {
     @In
     public String inGeopaparazzi = null;
 
-    @Description(OMSGEOPAPARAZZICONVERTER_doNotes_DESCRIPTION)
+    @Description(OMSGEOPAPARAZZICONVERTER_DO_NOTES_DESCRIPTION)
     @In
     public boolean doNotes = true;
 
-    @Description(OMSGEOPAPARAZZICONVERTER_doLoglines_DESCRIPTION)
+    @Description(OMSGEOPAPARAZZICONVERTER_DO_LOG_LINES_DESCRIPTION)
     @In
     public boolean doLoglines = true;
 
-    @Description(OMSGEOPAPARAZZICONVERTER_doLogpoints_DESCRIPTION)
+    @Description(OMSGEOPAPARAZZICONVERTER_DO_LOG_POINTS_DESCRIPTION)
     @In
     public boolean doLogpoints = false;
 
-    @Description(OMSGEOPAPARAZZICONVERTER_doMedia_DESCRIPTION)
+    @Description(OMSGEOPAPARAZZICONVERTER_DO_MEDIA_DESCRIPTION)
     @In
     public boolean doMedia = true;
 
-    @Description(OMSGEOPAPARAZZICONVERTER_outData_DESCRIPTION)
+    @Description(OMSGEOPAPARAZZICONVERTER_OUTDATA_DESCRIPTION)
     @UI(JGTConstants.FOLDEROUT_UI_HINT)
     @In
     public String outData = null;

--- a/modules/src/main/java/org/jgrasstools/modules/LineSmootherMcMaster.java
+++ b/modules/src/main/java/org/jgrasstools/modules/LineSmootherMcMaster.java
@@ -25,13 +25,13 @@ import static org.jgrasstools.gears.i18n.GearsMessages.OMSLINESMOOTHERMCMASTER_L
 import static org.jgrasstools.gears.i18n.GearsMessages.OMSLINESMOOTHERMCMASTER_LICENSE;
 import static org.jgrasstools.gears.i18n.GearsMessages.OMSLINESMOOTHERMCMASTER_NAME;
 import static org.jgrasstools.gears.i18n.GearsMessages.OMSLINESMOOTHERMCMASTER_STATUS;
-import static org.jgrasstools.gears.i18n.GearsMessages.OMSLINESMOOTHERMCMASTER_inVector_DESCRIPTION;
-import static org.jgrasstools.gears.i18n.GearsMessages.OMSLINESMOOTHERMCMASTER_outVector_DESCRIPTION;
-import static org.jgrasstools.gears.i18n.GearsMessages.OMSLINESMOOTHERMCMASTER_pDensify_DESCRIPTION;
-import static org.jgrasstools.gears.i18n.GearsMessages.OMSLINESMOOTHERMCMASTER_pLimit_DESCRIPTION;
-import static org.jgrasstools.gears.i18n.GearsMessages.OMSLINESMOOTHERMCMASTER_pLookahead_DESCRIPTION;
-import static org.jgrasstools.gears.i18n.GearsMessages.OMSLINESMOOTHERMCMASTER_pSimplify_DESCRIPTION;
-import static org.jgrasstools.gears.i18n.GearsMessages.OMSLINESMOOTHERMCMASTER_pSlide_DESCRIPTION;
+import static org.jgrasstools.gears.i18n.GearsMessages.OMSLINESMOOTHERMCMASTER_IN_VECTOR_DESCRIPTION;
+import static org.jgrasstools.gears.i18n.GearsMessages.OMSLINESMOOTHERMCMASTER_OUT_VECTOR_DESCRIPTION;
+import static org.jgrasstools.gears.i18n.GearsMessages.OMSLINESMOOTHERMCMASTER_P_DENSIFY_DESCRIPTION;
+import static org.jgrasstools.gears.i18n.GearsMessages.OMSLINESMOOTHERMCMASTER_P_LIMIT_DESCRIPTION;
+import static org.jgrasstools.gears.i18n.GearsMessages.OMSLINESMOOTHERMCMASTER_P_LOOK_AHEAD_DESCRIPTION;
+import static org.jgrasstools.gears.i18n.GearsMessages.OMSLINESMOOTHERMCMASTER_P_SIMPLIFY_DESCRIPTION;
+import static org.jgrasstools.gears.i18n.GearsMessages.OMSLINESMOOTHERMCMASTER_P_SLIDE_DESCRIPTION;
 import oms3.annotations.Author;
 import oms3.annotations.Description;
 import oms3.annotations.Execute;
@@ -56,32 +56,32 @@ import org.jgrasstools.gears.modules.v.smoothing.OmsLineSmootherMcMaster;
 @License(OMSLINESMOOTHERMCMASTER_LICENSE)
 public class LineSmootherMcMaster extends JGTModel {
 
-    @Description(OMSLINESMOOTHERMCMASTER_inVector_DESCRIPTION)
+    @Description(OMSLINESMOOTHERMCMASTER_IN_VECTOR_DESCRIPTION)
     @UI(JGTConstants.FILEIN_UI_HINT)
     @In
     public String inVector;
 
-    @Description(OMSLINESMOOTHERMCMASTER_pLookahead_DESCRIPTION)
+    @Description(OMSLINESMOOTHERMCMASTER_P_LOOK_AHEAD_DESCRIPTION)
     @In
     public int pLookahead = 7;
 
-    @Description(OMSLINESMOOTHERMCMASTER_pLimit_DESCRIPTION)
+    @Description(OMSLINESMOOTHERMCMASTER_P_LIMIT_DESCRIPTION)
     @In
     public int pLimit = 0;
 
-    @Description(OMSLINESMOOTHERMCMASTER_pSlide_DESCRIPTION)
+    @Description(OMSLINESMOOTHERMCMASTER_P_SLIDE_DESCRIPTION)
     @In
     public double pSlide = 0.9;
 
-    @Description(OMSLINESMOOTHERMCMASTER_pDensify_DESCRIPTION)
+    @Description(OMSLINESMOOTHERMCMASTER_P_DENSIFY_DESCRIPTION)
     @In
     public Double pDensify = null;
 
-    @Description(OMSLINESMOOTHERMCMASTER_pSimplify_DESCRIPTION)
+    @Description(OMSLINESMOOTHERMCMASTER_P_SIMPLIFY_DESCRIPTION)
     @In
     public Double pSimplify = null;
 
-    @Description(OMSLINESMOOTHERMCMASTER_outVector_DESCRIPTION)
+    @Description(OMSLINESMOOTHERMCMASTER_OUT_VECTOR_DESCRIPTION)
     @UI(JGTConstants.FILEOUT_UI_HINT)
     @In
     public String outVector;

--- a/modules/src/main/java/org/jgrasstools/modules/LinesRasterizer.java
+++ b/modules/src/main/java/org/jgrasstools/modules/LinesRasterizer.java
@@ -25,16 +25,16 @@ import static org.jgrasstools.gears.i18n.GearsMessages.OMSLINESRASTERIZER_LABEL;
 import static org.jgrasstools.gears.i18n.GearsMessages.OMSLINESRASTERIZER_LICENSE;
 import static org.jgrasstools.gears.i18n.GearsMessages.OMSLINESRASTERIZER_NAME;
 import static org.jgrasstools.gears.i18n.GearsMessages.OMSLINESRASTERIZER_STATUS;
-import static org.jgrasstools.gears.i18n.GearsMessages.OMSLINESRASTERIZER_fCat_DESCRIPTION;
-import static org.jgrasstools.gears.i18n.GearsMessages.OMSLINESRASTERIZER_inVector_DESCRIPTION;
-import static org.jgrasstools.gears.i18n.GearsMessages.OMSLINESRASTERIZER_outRaster_DESCRIPTION;
-import static org.jgrasstools.gears.i18n.GearsMessages.OMSLINESRASTERIZER_pCat_DESCRIPTION;
-import static org.jgrasstools.gears.i18n.GearsMessages.OMSLINESRASTERIZER_pCols_DESCRIPTION;
-import static org.jgrasstools.gears.i18n.GearsMessages.OMSLINESRASTERIZER_pEast_DESCRIPTION;
-import static org.jgrasstools.gears.i18n.GearsMessages.OMSLINESRASTERIZER_pNorth_DESCRIPTION;
-import static org.jgrasstools.gears.i18n.GearsMessages.OMSLINESRASTERIZER_pRows_DESCRIPTION;
-import static org.jgrasstools.gears.i18n.GearsMessages.OMSLINESRASTERIZER_pSouth_DESCRIPTION;
-import static org.jgrasstools.gears.i18n.GearsMessages.OMSLINESRASTERIZER_pWest_DESCRIPTION;
+import static org.jgrasstools.gears.i18n.GearsMessages.OMSLINESRASTERIZER_F_CAT_DESCRIPTION;
+import static org.jgrasstools.gears.i18n.GearsMessages.OMSLINESRASTERIZER_IN_VECTOR_DESCRIPTION;
+import static org.jgrasstools.gears.i18n.GearsMessages.OMSLINESRASTERIZER_OUT_RASTER_DESCRIPTION;
+import static org.jgrasstools.gears.i18n.GearsMessages.OMSLINESRASTERIZER_P_CAT_DESCRIPTION;
+import static org.jgrasstools.gears.i18n.GearsMessages.OMSLINESRASTERIZER_P_COLS_DESCRIPTION;
+import static org.jgrasstools.gears.i18n.GearsMessages.OMSLINESRASTERIZER_P_EAST_DESCRIPTION;
+import static org.jgrasstools.gears.i18n.GearsMessages.OMSLINESRASTERIZER_P_NORTH_DESCRIPTION;
+import static org.jgrasstools.gears.i18n.GearsMessages.OMSLINESRASTERIZER_P_ROWS_DESCRIPTION;
+import static org.jgrasstools.gears.i18n.GearsMessages.OMSLINESRASTERIZER_P_SOUTH_DESCRIPTION;
+import static org.jgrasstools.gears.i18n.GearsMessages.OMSLINESRASTERIZER_P_WEST_DESCRIPTION;
 import oms3.annotations.Author;
 import oms3.annotations.Description;
 import oms3.annotations.Execute;
@@ -59,50 +59,50 @@ import org.jgrasstools.gears.modules.r.linesrasterizer.OmsLinesRasterizer;
 @License(OMSLINESRASTERIZER_LICENSE)
 public class LinesRasterizer extends JGTModel {
 
-    @Description(OMSLINESRASTERIZER_inVector_DESCRIPTION)
+    @Description(OMSLINESRASTERIZER_IN_VECTOR_DESCRIPTION)
     @UI(JGTConstants.FILEIN_UI_HINT)
     @In
     public String inVector = null;
 
-    @Description(OMSLINESRASTERIZER_fCat_DESCRIPTION)
+    @Description(OMSLINESRASTERIZER_F_CAT_DESCRIPTION)
     @In
     public String fCat;
 
-    @Description(OMSLINESRASTERIZER_pCat_DESCRIPTION)
+    @Description(OMSLINESRASTERIZER_P_CAT_DESCRIPTION)
     @In
     public double pCat = 1.0;
 
-    @Description(OMSLINESRASTERIZER_pNorth_DESCRIPTION)
+    @Description(OMSLINESRASTERIZER_P_NORTH_DESCRIPTION)
     @UI(JGTConstants.PROCESS_NORTH_UI_HINT)
     @In
     public Double pNorth = null;
 
-    @Description(OMSLINESRASTERIZER_pSouth_DESCRIPTION)
+    @Description(OMSLINESRASTERIZER_P_SOUTH_DESCRIPTION)
     @UI(JGTConstants.PROCESS_SOUTH_UI_HINT)
     @In
     public Double pSouth = null;
 
-    @Description(OMSLINESRASTERIZER_pWest_DESCRIPTION)
+    @Description(OMSLINESRASTERIZER_P_WEST_DESCRIPTION)
     @UI(JGTConstants.PROCESS_WEST_UI_HINT)
     @In
     public Double pWest = null;
 
-    @Description(OMSLINESRASTERIZER_pEast_DESCRIPTION)
+    @Description(OMSLINESRASTERIZER_P_EAST_DESCRIPTION)
     @UI(JGTConstants.PROCESS_EAST_UI_HINT)
     @In
     public Double pEast = null;
 
-    @Description(OMSLINESRASTERIZER_pRows_DESCRIPTION)
+    @Description(OMSLINESRASTERIZER_P_ROWS_DESCRIPTION)
     @UI(JGTConstants.PROCESS_ROWS_UI_HINT)
     @In
     public Integer pRows = null;
 
-    @Description(OMSLINESRASTERIZER_pCols_DESCRIPTION)
+    @Description(OMSLINESRASTERIZER_P_COLS_DESCRIPTION)
     @UI(JGTConstants.PROCESS_COLS_UI_HINT)
     @In
     public Integer pCols = null;
 
-    @Description(OMSLINESRASTERIZER_outRaster_DESCRIPTION)
+    @Description(OMSLINESRASTERIZER_OUT_RASTER_DESCRIPTION)
     @UI(JGTConstants.FILEOUT_UI_HINT)
     @In
     public String outRaster;

--- a/modules/src/main/java/org/jgrasstools/modules/PointsVectorizer.java
+++ b/modules/src/main/java/org/jgrasstools/modules/PointsVectorizer.java
@@ -25,9 +25,9 @@ import static org.jgrasstools.gears.i18n.GearsMessages.OMSPOINTSVECTORIZER_LABEL
 import static org.jgrasstools.gears.i18n.GearsMessages.OMSPOINTSVECTORIZER_LICENSE;
 import static org.jgrasstools.gears.i18n.GearsMessages.OMSPOINTSVECTORIZER_NAME;
 import static org.jgrasstools.gears.i18n.GearsMessages.OMSPOINTSVECTORIZER_STATUS;
-import static org.jgrasstools.gears.i18n.GearsMessages.OMSPOINTSVECTORIZER_fDefault_DESCRIPTION;
-import static org.jgrasstools.gears.i18n.GearsMessages.OMSPOINTSVECTORIZER_inRaster_DESCRIPTION;
-import static org.jgrasstools.gears.i18n.GearsMessages.OMSPOINTSVECTORIZER_outVector_DESCRIPTION;
+import static org.jgrasstools.gears.i18n.GearsMessages.OMSPOINTSVECTORIZER_F_DEFAULT_DESCRIPTION;
+import static org.jgrasstools.gears.i18n.GearsMessages.OMSPOINTSVECTORIZER_IN_RASTER_DESCRIPTION;
+import static org.jgrasstools.gears.i18n.GearsMessages.OMSPOINTSVECTORIZER_OUT_VECTOR_DESCRIPTION;
 import oms3.annotations.Author;
 import oms3.annotations.Description;
 import oms3.annotations.Execute;
@@ -52,16 +52,16 @@ import org.jgrasstools.gears.modules.v.vectorize.OmsPointsVectorizer;
 @License(OMSPOINTSVECTORIZER_LICENSE)
 public class PointsVectorizer extends JGTModel {
 
-    @Description(OMSPOINTSVECTORIZER_inRaster_DESCRIPTION)
+    @Description(OMSPOINTSVECTORIZER_IN_RASTER_DESCRIPTION)
     @UI(JGTConstants.FILEIN_UI_HINT)
     @In
     public String inRaster;
 
-    @Description(OMSPOINTSVECTORIZER_fDefault_DESCRIPTION)
+    @Description(OMSPOINTSVECTORIZER_F_DEFAULT_DESCRIPTION)
     @In
     public String fDefault = "value";
 
-    @Description(OMSPOINTSVECTORIZER_outVector_DESCRIPTION)
+    @Description(OMSPOINTSVECTORIZER_OUT_VECTOR_DESCRIPTION)
     @UI(JGTConstants.FILEOUT_UI_HINT)
     @In
     public String outVector = null;

--- a/modules/src/main/java/org/jgrasstools/modules/RasterConverter.java
+++ b/modules/src/main/java/org/jgrasstools/modules/RasterConverter.java
@@ -17,14 +17,14 @@
  */
 package org.jgrasstools.modules;
 
-import static org.jgrasstools.gears.i18n.GearsMessages.GENERIC_pCols_DESCRIPTION;
-import static org.jgrasstools.gears.i18n.GearsMessages.GENERIC_pEast_DESCRIPTION;
-import static org.jgrasstools.gears.i18n.GearsMessages.GENERIC_pNorth_DESCRIPTION;
-import static org.jgrasstools.gears.i18n.GearsMessages.GENERIC_pRows_DESCRIPTION;
-import static org.jgrasstools.gears.i18n.GearsMessages.GENERIC_pSouth_DESCRIPTION;
-import static org.jgrasstools.gears.i18n.GearsMessages.GENERIC_pWest_DESCRIPTION;
-import static org.jgrasstools.gears.i18n.GearsMessages.GENERIC_pXres_DESCRIPTION;
-import static org.jgrasstools.gears.i18n.GearsMessages.GENERIC_pYres_DESCRIPTION;
+import static org.jgrasstools.gears.i18n.GearsMessages.GENERIC_P_COLS_DESCRIPTION;
+import static org.jgrasstools.gears.i18n.GearsMessages.GENERIC_P_EAST_DESCRIPTION;
+import static org.jgrasstools.gears.i18n.GearsMessages.GENERIC_P_NORTH_DESCRIPTION;
+import static org.jgrasstools.gears.i18n.GearsMessages.GENERIC_P_ROWS_DESCRIPTION;
+import static org.jgrasstools.gears.i18n.GearsMessages.GENERIC_P_SOUTH_DESCRIPTION;
+import static org.jgrasstools.gears.i18n.GearsMessages.GENERIC_P_WEST_DESCRIPTION;
+import static org.jgrasstools.gears.i18n.GearsMessages.GENERIC_P_X_RES_DESCRIPTION;
+import static org.jgrasstools.gears.i18n.GearsMessages.GENERIC_P_Y_RES_DESCRIPTION;
 import static org.jgrasstools.gears.i18n.GearsMessages.OMSRASTERCONVERTER_inRaster_DESCRIPTION;
 import static org.jgrasstools.gears.i18n.GearsMessages.OMSRASTERCONVERTER_outRaster_DESCRIPTION;
 import oms3.annotations.Description;
@@ -45,42 +45,42 @@ public class RasterConverter extends OmsRasterConverter {
     @In
     public String inRaster;
 
-    @Description(GENERIC_pNorth_DESCRIPTION)
+    @Description(GENERIC_P_NORTH_DESCRIPTION)
     @UI(JGTConstants.PROCESS_NORTH_UI_HINT)
     @In
     public Double pNorth = null;
 
-    @Description(GENERIC_pSouth_DESCRIPTION)
+    @Description(GENERIC_P_SOUTH_DESCRIPTION)
     @UI(JGTConstants.PROCESS_SOUTH_UI_HINT)
     @In
     public Double pSouth = null;
 
-    @Description(GENERIC_pWest_DESCRIPTION)
+    @Description(GENERIC_P_WEST_DESCRIPTION)
     @UI(JGTConstants.PROCESS_WEST_UI_HINT)
     @In
     public Double pWest = null;
 
-    @Description(GENERIC_pEast_DESCRIPTION)
+    @Description(GENERIC_P_EAST_DESCRIPTION)
     @UI(JGTConstants.PROCESS_EAST_UI_HINT)
     @In
     public Double pEast = null;
     
-    @Description(GENERIC_pXres_DESCRIPTION)
+    @Description(GENERIC_P_X_RES_DESCRIPTION)
     @UI(JGTConstants.PROCESS_XRES_UI_HINT)
     @In
     public Double pXres = null;
 
-    @Description(GENERIC_pYres_DESCRIPTION)
+    @Description(GENERIC_P_Y_RES_DESCRIPTION)
     @UI(JGTConstants.PROCESS_YRES_UI_HINT)
     @In
     public Double pYres = null;
 
-    @Description(GENERIC_pRows_DESCRIPTION)
+    @Description(GENERIC_P_ROWS_DESCRIPTION)
     @UI(JGTConstants.PROCESS_ROWS_UI_HINT)
     @In
     public Integer pRows = null;
 
-    @Description(GENERIC_pCols_DESCRIPTION)
+    @Description(GENERIC_P_COLS_DESCRIPTION)
     @UI(JGTConstants.PROCESS_COLS_UI_HINT)
     @In
     public Integer pCols = null;

--- a/modules/src/main/java/org/jgrasstools/modules/RasterVectorIntersector.java
+++ b/modules/src/main/java/org/jgrasstools/modules/RasterVectorIntersector.java
@@ -25,10 +25,10 @@ import static org.jgrasstools.gears.i18n.GearsMessages.OMSRASTERVECTORINTERSECTO
 import static org.jgrasstools.gears.i18n.GearsMessages.OMSRASTERVECTORINTERSECTOR_LICENSE;
 import static org.jgrasstools.gears.i18n.GearsMessages.OMSRASTERVECTORINTERSECTOR_NAME;
 import static org.jgrasstools.gears.i18n.GearsMessages.OMSRASTERVECTORINTERSECTOR_STATUS;
-import static org.jgrasstools.gears.i18n.GearsMessages.OMSRASTERVECTORINTERSECTOR_doInverse_DESCRIPTION;
-import static org.jgrasstools.gears.i18n.GearsMessages.OMSRASTERVECTORINTERSECTOR_inRaster_DESCRIPTION;
-import static org.jgrasstools.gears.i18n.GearsMessages.OMSRASTERVECTORINTERSECTOR_inVector_DESCRIPTION;
-import static org.jgrasstools.gears.i18n.GearsMessages.OMSRASTERVECTORINTERSECTOR_outRaster_DESCRIPTION;
+import static org.jgrasstools.gears.i18n.GearsMessages.OMSRASTERVECTORINTERSECTOR_DO_INVERSE_DESCRIPTION;
+import static org.jgrasstools.gears.i18n.GearsMessages.OMSRASTERVECTORINTERSECTOR_IN_RASTER_DESCRIPTION;
+import static org.jgrasstools.gears.i18n.GearsMessages.OMSRASTERVECTORINTERSECTOR_IN_VECTOR_DESCRIPTION;
+import static org.jgrasstools.gears.i18n.GearsMessages.OMSRASTERVECTORINTERSECTOR_OUT_RASTER_DESCRIPTION;
 import oms3.annotations.Author;
 import oms3.annotations.Description;
 import oms3.annotations.Execute;
@@ -53,21 +53,21 @@ import org.jgrasstools.gears.modules.r.rastervectorintersection.OmsRasterVectorI
 @License(OMSRASTERVECTORINTERSECTOR_LICENSE)
 public class RasterVectorIntersector extends JGTModel {
 
-    @Description(OMSRASTERVECTORINTERSECTOR_inVector_DESCRIPTION)
+    @Description(OMSRASTERVECTORINTERSECTOR_IN_VECTOR_DESCRIPTION)
     @UI(JGTConstants.FILEIN_UI_HINT)
     @In
     public String inVector = null;
 
-    @Description(OMSRASTERVECTORINTERSECTOR_inRaster_DESCRIPTION)
+    @Description(OMSRASTERVECTORINTERSECTOR_IN_RASTER_DESCRIPTION)
     @UI(JGTConstants.FILEIN_UI_HINT)
     @In
     public String inRaster;
 
-    @Description(OMSRASTERVECTORINTERSECTOR_doInverse_DESCRIPTION)
+    @Description(OMSRASTERVECTORINTERSECTOR_DO_INVERSE_DESCRIPTION)
     @In
     public boolean doInverse = false;
 
-    @Description(OMSRASTERVECTORINTERSECTOR_outRaster_DESCRIPTION)
+    @Description(OMSRASTERVECTORINTERSECTOR_OUT_RASTER_DESCRIPTION)
     @UI(JGTConstants.FILEOUT_UI_HINT)
     @In
     public String outRaster;

--- a/modules/src/main/java/org/jgrasstools/modules/RasterWriter.java
+++ b/modules/src/main/java/org/jgrasstools/modules/RasterWriter.java
@@ -25,8 +25,8 @@ import static org.jgrasstools.gears.i18n.GearsMessages.OMSRASTERWRITER_LABEL;
 import static org.jgrasstools.gears.i18n.GearsMessages.OMSRASTERWRITER_LICENSE;
 import static org.jgrasstools.gears.i18n.GearsMessages.OMSRASTERWRITER_NAME;
 import static org.jgrasstools.gears.i18n.GearsMessages.OMSRASTERWRITER_STATUS;
-import static org.jgrasstools.gears.i18n.GearsMessages.OMSRASTERWRITER_file_DESCRIPTION;
-import static org.jgrasstools.gears.i18n.GearsMessages.OMSRASTERWRITER_inRaster_DESCRIPTION;
+import static org.jgrasstools.gears.i18n.GearsMessages.OMSRASTERWRITER_FILE_DESCRIPTION;
+import static org.jgrasstools.gears.i18n.GearsMessages.OMSRASTERWRITER_IN_RASTER_DESCRIPTION;
 import oms3.annotations.Author;
 import oms3.annotations.Description;
 import oms3.annotations.Execute;
@@ -52,11 +52,11 @@ import org.jgrasstools.gears.libs.modules.JGTModel;
 @License(OMSRASTERWRITER_LICENSE)
 public class RasterWriter extends JGTModel {
 
-    @Description(OMSRASTERWRITER_inRaster_DESCRIPTION)
+    @Description(OMSRASTERWRITER_IN_RASTER_DESCRIPTION)
     @In
     public GridCoverage2D inRaster = null;
 
-    @Description(OMSRASTERWRITER_file_DESCRIPTION)
+    @Description(OMSRASTERWRITER_FILE_DESCRIPTION)
     @UI(JGTConstants.FILEOUT_UI_HINT)
     @In
     public String file = null;

--- a/modules/src/main/java/org/jgrasstools/modules/VectorConverter.java
+++ b/modules/src/main/java/org/jgrasstools/modules/VectorConverter.java
@@ -27,8 +27,8 @@ import static org.jgrasstools.gears.i18n.GearsMessages.OMSVECTORCONVERTER_LICENS
 import static org.jgrasstools.gears.i18n.GearsMessages.OMSVECTORCONVERTER_NAME;
 import static org.jgrasstools.gears.i18n.GearsMessages.OMSVECTORCONVERTER_STATUS;
 import static org.jgrasstools.gears.i18n.GearsMessages.OMSVECTORCONVERTER_UI;
-import static org.jgrasstools.gears.i18n.GearsMessages.OMSVECTORCONVERTER_inGeodata_DESCRIPTION;
-import static org.jgrasstools.gears.i18n.GearsMessages.OMSVECTORCONVERTER_outGeodata_DESCRIPTION;
+import static org.jgrasstools.gears.i18n.GearsMessages.OMSVECTORCONVERTER_IN_GEODATA_DESCRIPTION;
+import static org.jgrasstools.gears.i18n.GearsMessages.OMSVECTORCONVERTER_OUT_GEODATA_DESCRIPTION;
 import oms3.annotations.Author;
 import oms3.annotations.Description;
 import oms3.annotations.Execute;
@@ -54,12 +54,12 @@ import org.jgrasstools.gears.modules.v.vectorconverter.OmsVectorConverter;
 @UI(OMSVECTORCONVERTER_UI)
 public class VectorConverter extends JGTModel {
 
-    @Description(OMSVECTORCONVERTER_inGeodata_DESCRIPTION)
+    @Description(OMSVECTORCONVERTER_IN_GEODATA_DESCRIPTION)
     @UI(JGTConstants.FILEIN_UI_HINT)
     @In
     public String inGeodata;
 
-    @Description(OMSVECTORCONVERTER_outGeodata_DESCRIPTION)
+    @Description(OMSVECTORCONVERTER_OUT_GEODATA_DESCRIPTION)
     @UI(JGTConstants.FILEOUT_UI_HINT)
     @In
     public String outGeodata;

--- a/modules/src/main/java/org/jgrasstools/modules/VectorReader.java
+++ b/modules/src/main/java/org/jgrasstools/modules/VectorReader.java
@@ -25,8 +25,8 @@ import static org.jgrasstools.gears.i18n.GearsMessages.OMSVECTORREADER_LABEL;
 import static org.jgrasstools.gears.i18n.GearsMessages.OMSVECTORREADER_LICENSE;
 import static org.jgrasstools.gears.i18n.GearsMessages.OMSVECTORREADER_NAME;
 import static org.jgrasstools.gears.i18n.GearsMessages.OMSVECTORREADER_STATUS;
-import static org.jgrasstools.gears.i18n.GearsMessages.OMSVECTORREADER_file_DESCRIPTION;
-import static org.jgrasstools.gears.i18n.GearsMessages.OMSVECTORREADER_outVector_DESCRIPTION;
+import static org.jgrasstools.gears.i18n.GearsMessages.OMSVECTORREADER_FILE_DESCRIPTION;
+import static org.jgrasstools.gears.i18n.GearsMessages.OMSVECTORREADER_OUT_VECTOR_DESCRIPTION;
 
 import java.io.IOException;
 
@@ -55,12 +55,12 @@ import org.jgrasstools.gears.libs.modules.JGTModel;
 @License(OMSVECTORREADER_LICENSE)
 public class VectorReader extends JGTModel {
 
-    @Description(OMSVECTORREADER_file_DESCRIPTION)
+    @Description(OMSVECTORREADER_FILE_DESCRIPTION)
     @UI(JGTConstants.FILEIN_UI_HINT)
     @In
     public String file = null;
 
-    @Description(OMSVECTORREADER_outVector_DESCRIPTION)
+    @Description(OMSVECTORREADER_OUT_VECTOR_DESCRIPTION)
     @In
     public SimpleFeatureCollection outVector = null;
 

--- a/modules/src/main/java/org/jgrasstools/modules/WindowSampler.java
+++ b/modules/src/main/java/org/jgrasstools/modules/WindowSampler.java
@@ -26,13 +26,13 @@ import static org.jgrasstools.gears.i18n.GearsMessages.OMSWINDOWSAMPLER_LABEL;
 import static org.jgrasstools.gears.i18n.GearsMessages.OMSWINDOWSAMPLER_LICENSE;
 import static org.jgrasstools.gears.i18n.GearsMessages.OMSWINDOWSAMPLER_NAME;
 import static org.jgrasstools.gears.i18n.GearsMessages.OMSWINDOWSAMPLER_STATUS;
-import static org.jgrasstools.gears.i18n.GearsMessages.OMSWINDOWSAMPLER_inGeodata_DESCRIPTION;
-import static org.jgrasstools.gears.i18n.GearsMessages.OMSWINDOWSAMPLER_outGeodata_DESCRIPTION;
-import static org.jgrasstools.gears.i18n.GearsMessages.OMSWINDOWSAMPLER_pCols_DESCRIPTION;
-import static org.jgrasstools.gears.i18n.GearsMessages.OMSWINDOWSAMPLER_pMode_DESCRIPTION;
-import static org.jgrasstools.gears.i18n.GearsMessages.OMSWINDOWSAMPLER_pRows_DESCRIPTION;
-import static org.jgrasstools.gears.i18n.GearsMessages.OMSWINDOWSAMPLER_pXstep_DESCRIPTION;
-import static org.jgrasstools.gears.i18n.GearsMessages.OMSWINDOWSAMPLER_pYstep_DESCRIPTION;
+import static org.jgrasstools.gears.i18n.GearsMessages.OMSWINDOWSAMPLER_IN_GEODATA_DESCRIPTION;
+import static org.jgrasstools.gears.i18n.GearsMessages.OMSWINDOWSAMPLER_OUT_GEODATA_DESCRIPTION;
+import static org.jgrasstools.gears.i18n.GearsMessages.OMSWINDOWSAMPLER_P_COLS_DESCRIPTION;
+import static org.jgrasstools.gears.i18n.GearsMessages.OMSWINDOWSAMPLER_P_MODE_DESCRIPTION;
+import static org.jgrasstools.gears.i18n.GearsMessages.OMSWINDOWSAMPLER_P_ROWS_DESCRIPTION;
+import static org.jgrasstools.gears.i18n.GearsMessages.OMSWINDOWSAMPLER_P_X_STEP_DESCRIPTION;
+import static org.jgrasstools.gears.i18n.GearsMessages.OMSWINDOWSAMPLER_P_Y_STEP_DESCRIPTION;
 import oms3.annotations.Author;
 import oms3.annotations.Description;
 import oms3.annotations.Execute;
@@ -57,32 +57,32 @@ import org.jgrasstools.gears.modules.r.windowsampler.OmsWindowSampler;
 @License(OMSWINDOWSAMPLER_LICENSE)
 public class WindowSampler extends JGTModel {
 
-    @Description(OMSWINDOWSAMPLER_inGeodata_DESCRIPTION)
+    @Description(OMSWINDOWSAMPLER_IN_GEODATA_DESCRIPTION)
     @UI(JGTConstants.FILEIN_UI_HINT)
     @In
     public String inGeodata;
 
-    @Description(OMSWINDOWSAMPLER_pMode_DESCRIPTION)
+    @Description(OMSWINDOWSAMPLER_P_MODE_DESCRIPTION)
     @In
     public int pMode = 0;
 
-    @Description(OMSWINDOWSAMPLER_pRows_DESCRIPTION)
+    @Description(OMSWINDOWSAMPLER_P_ROWS_DESCRIPTION)
     @In
     public int pRows = 3;
 
-    @Description(OMSWINDOWSAMPLER_pCols_DESCRIPTION)
+    @Description(OMSWINDOWSAMPLER_P_COLS_DESCRIPTION)
     @In
     public int pCols = 3;
 
-    @Description(OMSWINDOWSAMPLER_pXstep_DESCRIPTION)
+    @Description(OMSWINDOWSAMPLER_P_X_STEP_DESCRIPTION)
     @In
     public Integer pXstep;
 
-    @Description(OMSWINDOWSAMPLER_pYstep_DESCRIPTION)
+    @Description(OMSWINDOWSAMPLER_P_Y_STEP_DESCRIPTION)
     @In
     public Integer pYstep;
 
-    @Description(OMSWINDOWSAMPLER_outGeodata_DESCRIPTION)
+    @Description(OMSWINDOWSAMPLER_OUT_GEODATA_DESCRIPTION)
     @UI(JGTConstants.FILEOUT_UI_HINT)
     @In
     public String outGeodata;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S00115 - Constant names should comply with a naming convention.
squid:S1118 - Utility classes should not have public constructors.
squid:S2147 - Catches should be combined.
squid:S2293 - The diamond operator ("<>") should be used.
squid:S1488 - Local Variables should not be declared and then immediately returned or thrown.
squid:S1192 - String literals should not be duplicated.
squid:CommentedOutCodeLine - Sections of code should not be "commented out".
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S00115
https://dev.eclipse.org/sonar/rules/show/squid:S1118
https://dev.eclipse.org/sonar/rules/show/squid:S2147
https://dev.eclipse.org/sonar/rules/show/squid:S2293
https://dev.eclipse.org/sonar/rules/show/squid:S1488
https://dev.eclipse.org/sonar/rules/show/squid:S1192
https://dev.eclipse.org/sonar/rules/show/squid:CommentedOutCodeLine
Please let me know if you have any questions.
George Kankava