### PR TITLE
multiple code improvements: squid:S00115, squid:ClassVariableVisibilityCheck, squid:S1319, squid:S00117, squid:S00116, squid:S2293

### DIFF
--- a/hortonmachine/src/main/java/org/jgrasstools/hortonmachine/modules/hydrogeomorphology/adige/duffy/DuffyAdigeEngine.java
+++ b/hortonmachine/src/main/java/org/jgrasstools/hortonmachine/modules/hydrogeomorphology/adige/duffy/DuffyAdigeEngine.java
@@ -113,10 +113,10 @@ public class DuffyAdigeEngine implements IAdigeEngine {
                 if (index == null)
                     continue;
                 AdigeBoundaryCondition condition = entry.getValue();
-                initialConditions[index] = condition.discharge;
-                initialConditions[index + hillsSlopeNum] = condition.dischargeSub;
-                initialConditions[index + 2 * hillsSlopeNum] = condition.S1;
-                initialConditions[index + 3 * hillsSlopeNum] = condition.S2;
+                initialConditions[index] = condition.getDischarge();
+                initialConditions[index + hillsSlopeNum] = condition.getDischargeSub();
+                initialConditions[index + 2 * hillsSlopeNum] = condition.getS1();
+                initialConditions[index + 3 * hillsSlopeNum] = condition.getS2();
             }
         } else {
             double startSubsuperficialDischargeFraction = 1.0 - inDuffyInput.pStartSuperficialDischargeFraction;
@@ -188,11 +188,11 @@ public class DuffyAdigeEngine implements IAdigeEngine {
             }
             if (inDuffyInput.doBoundary) {
                 AdigeBoundaryCondition bc = new AdigeBoundaryCondition();
-                bc.basinId = basinId;
-                bc.discharge = discharge[0];
-                bc.dischargeSub = subdischarge[0];
-                bc.S1 = s1[0];
-                bc.S2 = s2[0];
+                bc.setBasinId(basinId);
+                bc.setDischarge(discharge[0]);
+                bc.setDischargeSub(subdischarge[0]);
+                bc.setS1(s1[0]);
+                bc.setS2(s2[0]);
                 inDuffyInput.outFinalconditions.put(basinId, bc);
             }
         }

--- a/jgrassgears/src/main/java/org/jgrasstools/gears/i18n/GearsMessages.java
+++ b/jgrassgears/src/main/java/org/jgrasstools/gears/i18n/GearsMessages.java
@@ -1079,7 +1079,7 @@ public class GearsMessages {
     public static final String GRASSMOSAICLEGACY_LICENSE = "General Public License Version 3 (GPLv3)";
     public static final String GRASSMOSAICLEGACY_AUTHORNAMES = "Andrea Antonello";
     public static final String GRASSMOSAICLEGACY_AUTHORCONTACTS = "http://www.hydrologis.com";
-    public static final String GRASSMOSAICLEGACY_inFiles_DESCRIPTION = "The list of files that have to be patched (used if inGeodata is null).";
+    public static final String GRASSMOSAICLEGACY_IN_FILES_DESCRIPTION = "The list of files that have to be patched (used if inGeodata is null).";
     public static final String GRASSMOSAICLEGACY_P_RES_DESCRIPTION = "The output file resolution in meters.";
     public static final String GRASSMOSAICLEGACY_P_BOUNDS_DESCRIPTION = "The optional requested boundary coordinates as array of [n, s, w, e].";
     public static final String GRASSMOSAICLEGACY_OUT_GRASS_FILE_DESCRIPTION = "The GRASS file path to which to write to.";
@@ -1236,11 +1236,11 @@ public class GearsMessages {
     public static final String OMSMARCHINGSQUARESVECTORIALIZER_AUTHORNAMES = "Andrea Antonello, Daniele Andreis";
     public static final String OMSMARCHINGSQUARESVECTORIALIZER_AUTHORCONTACTS = "www.hydrologis.com";
     public static final String OMSMARCHINGSQUARESVECTORIALIZER_UI = "hide";
-    public static final String OMSMARCHINGSQUARESVECTORIALIZER_inGeodata_DESCRIPTION = "The coverage that has to be converted.";
-    public static final String OMSMARCHINGSQUARESVECTORIALIZER_pValue_DESCRIPTION = "The value to use to trace the polygons. If it is null then all the value of the raster are used";
-    public static final String OMSMARCHINGSQUARESVECTORIALIZER_defaultFeatureField_DESCRIPTION = "The value to use as a name for the raster value in the Feature.";
-    public static final String OMSMARCHINGSQUARESVECTORIALIZER_pThres_DESCRIPTION = "A threshold on cell number to filter away polygons with cells less than that.";
-    public static final String OMSMARCHINGSQUARESVECTORIALIZER_outGeodata_DESCRIPTION = "The extracted features.";
+    public static final String OMSMARCHINGSQUARESVECTORIALIZER_IN_GEODATA_DESCRIPTION = "The coverage that has to be converted.";
+    public static final String OMSMARCHINGSQUARESVECTORIALIZER_P_VALUE_DESCRIPTION = "The value to use to trace the polygons. If it is null then all the value of the raster are used";
+    public static final String OMSMARCHINGSQUARESVECTORIALIZER_DEFAULT_FEATURE_FIELD_DESCRIPTION = "The value to use as a name for the raster value in the Feature.";
+    public static final String OMSMARCHINGSQUARESVECTORIALIZER_P_THRES_DESCRIPTION = "A threshold on cell number to filter away polygons with cells less than that.";
+    public static final String OMSMARCHINGSQUARESVECTORIALIZER_OUT_GEODATA_DESCRIPTION = "The extracted features.";
 
     public static final String OMSRASTERTRANSFORMER_DESCRIPTION = "Module for raster tranforms.";
     public static final String OMSRASTERTRANSFORMER_DOCUMENTATION = "";

--- a/jgrassgears/src/main/java/org/jgrasstools/gears/io/adige/AdigeBoundaryCondition.java
+++ b/jgrassgears/src/main/java/org/jgrasstools/gears/io/adige/AdigeBoundaryCondition.java
@@ -24,9 +24,40 @@ package org.jgrasstools.gears.io.adige;
  * @author Andrea Antonello (www.hydrologis.com)
  */
 public class AdigeBoundaryCondition {
-    public int basinId = -1;
-    public double discharge = Double.NaN;
-    public double dischargeSub = Double.NaN;
-    public double S1 = Double.NaN;
-    public double S2 = Double.NaN;
+    private int basinId = -1;
+    private double discharge = Double.NaN;
+    private double dischargeSub = Double.NaN;
+    private double s1 = Double.NaN;
+    private double s2 = Double.NaN;
+
+    public int getBasinId() {
+        return basinId;
+    }
+    public void setBasinId(int basinId) {
+        this.basinId = basinId;
+    }
+    public double getDischarge() {
+        return discharge;
+    }
+    public void setDischarge(double discharge) {
+        this.discharge = discharge;
+    }
+    public double getDischargeSub() {
+        return dischargeSub;
+    }
+    public void setDischargeSub(double dischargeSub) {
+        this.dischargeSub = dischargeSub;
+    }
+    public double getS1() {
+        return s1;
+    }
+    public void setS1(double s1) {
+        this.s1 = s1;
+    }
+    public double getS2() {
+        return s2;
+    }
+    public void setS2(double s2) {
+        this.s2 = s2;
+    }
 }

--- a/jgrassgears/src/main/java/org/jgrasstools/gears/io/adige/AdigeBoundaryConditionReader.java
+++ b/jgrassgears/src/main/java/org/jgrasstools/gears/io/adige/AdigeBoundaryConditionReader.java
@@ -21,6 +21,7 @@ package org.jgrasstools.gears.io.adige;
 import java.io.File;
 import java.io.IOException;
 import java.util.HashMap;
+import java.util.Map;
 
 import oms3.annotations.Author;
 import oms3.annotations.Description;
@@ -59,7 +60,7 @@ public class AdigeBoundaryConditionReader extends JGTModel {
 
     @Description(ADIGEBOUNDARYCONDITIONREADER_DATA_DESCRIPTION)
     @Out
-    public HashMap<Integer, AdigeBoundaryCondition> data;
+    public Map<Integer, AdigeBoundaryCondition> data;
 
     private TableIterator<String[]> rowsIterator;
     private CSTable table;
@@ -77,19 +78,19 @@ public class AdigeBoundaryConditionReader extends JGTModel {
             return;
         }
         ensureOpen();
-        data = new HashMap<Integer, AdigeBoundaryCondition>();
+        data = new HashMap<>();
         while( rowsIterator.hasNext() ) {
             String[] row = rowsIterator.next();
 
             AdigeBoundaryCondition condition = new AdigeBoundaryCondition();
             int i = 1;
-            condition.basinId = (int) Double.parseDouble(row[i++]);
-            condition.discharge = Double.parseDouble(row[i++]);
-            condition.dischargeSub = Double.parseDouble(row[i++]);
-            condition.S1 = Double.parseDouble(row[i++]);
-            condition.S2 = Double.parseDouble(row[i]);
+            condition.setBasinId( (int) Double.parseDouble(row[i++]));
+            condition.setDischarge(Double.parseDouble(row[i++]));
+            condition.setDischargeSub(Double.parseDouble(row[i++]));
+            condition.setS1(Double.parseDouble(row[i++]));
+            condition.setS2(Double.parseDouble(row[i]));
 
-            data.put(condition.basinId, condition);
+            data.put(condition.getBasinId(), condition);
         }
     }
 

--- a/jgrassgears/src/main/java/org/jgrasstools/gears/io/adige/AdigeBoundaryConditionWriter.java
+++ b/jgrassgears/src/main/java/org/jgrasstools/gears/io/adige/AdigeBoundaryConditionWriter.java
@@ -33,7 +33,7 @@ import static org.jgrasstools.gears.i18n.GearsMessages.ADIGEBOUNDARYCONDITIONWRI
 import java.io.File;
 import java.io.IOException;
 import java.io.PrintWriter;
-import java.util.HashMap;
+import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 
@@ -76,7 +76,7 @@ public class AdigeBoundaryConditionWriter extends JGTModel {
 
     @Description(ADIGEBOUNDARYCONDITIONWRITER_DATA_DESCRIPTION)
     @In
-    public HashMap<Integer, AdigeBoundaryCondition> data;
+    public Map<Integer, AdigeBoundaryCondition> data;
 
     private MemoryTable memoryTable;
 
@@ -101,11 +101,11 @@ public class AdigeBoundaryConditionWriter extends JGTModel {
         for( Entry<Integer, AdigeBoundaryCondition> entry : entrySet ) {
             AdigeBoundaryCondition condition = entry.getValue();
             Object[] valuesRow = new Object[colNames.length];
-            valuesRow[0] = condition.basinId;
-            valuesRow[1] = condition.discharge;
-            valuesRow[2] = condition.dischargeSub;
-            valuesRow[3] = condition.S1;
-            valuesRow[4] = condition.S2;
+            valuesRow[0] = condition.getBasinId();
+            valuesRow[1] = condition.getDischarge();
+            valuesRow[2] = condition.getDischargeSub();
+            valuesRow[3] = condition.getS1();
+            valuesRow[4] = condition.getS2();
             memoryTable.addRow(valuesRow);
         }
     }

--- a/jgrassgears/src/main/java/org/jgrasstools/gears/io/adige/VegetationLibraryReader.java
+++ b/jgrassgears/src/main/java/org/jgrasstools/gears/io/adige/VegetationLibraryReader.java
@@ -32,6 +32,7 @@ import static org.jgrasstools.gears.i18n.GearsMessages.VEGETATIONLIBRARYREADER_F
 import java.io.File;
 import java.io.IOException;
 import java.util.HashMap;
+import java.util.Map;
 
 import oms3.annotations.Author;
 import oms3.annotations.Description;
@@ -68,7 +69,7 @@ public class VegetationLibraryReader extends JGTModel {
 
     @Description(VEGETATIONLIBRARYREADER_DATA_DESCRIPTION)
     @Out
-    public HashMap<Integer, VegetationLibraryRecord> data;
+    public Map<Integer, VegetationLibraryRecord> data;
 
     private TableIterator<String[]> rowsIterator;
 
@@ -87,14 +88,14 @@ public class VegetationLibraryReader extends JGTModel {
             return;
         }
         ensureOpen();
-        data = new HashMap<Integer, VegetationLibraryRecord>();
+        data = new HashMap<>();
         while( rowsIterator.hasNext() ) {
             String[] row = rowsIterator.next();
 
             int i = 1;
             int vegetationIndex = (int) Double.parseDouble(row[i++]);
-            double architectural_resistance = Double.parseDouble(row[i++]);
-            double min_stomatal_resistanc = Double.parseDouble(row[i++]);
+            double architecturalResistance = Double.parseDouble(row[i++]);
+            double minStomatalResistanc = Double.parseDouble(row[i++]);
 
             double[] laiMonths = new double[12];
             for( int j = 0; j < laiMonths.length; j++ ) {
@@ -113,15 +114,15 @@ public class VegetationLibraryReader extends JGTModel {
                 displMonths[j] = Double.parseDouble(row[i++]);
             }
 
-            double wind_height = Double.parseDouble(row[i++]);
+            double windHeight = Double.parseDouble(row[i++]);
             double rgl = Double.parseDouble(row[i++]);
-            double rad_atten = Double.parseDouble(row[i++]);
-            double wind_atten = Double.parseDouble(row[i++]);
-            double trunk_ratio = Double.parseDouble(row[i]);
+            double radAtten = Double.parseDouble(row[i++]);
+            double windAtten = Double.parseDouble(row[i++]);
+            double trunkRatio = Double.parseDouble(row[i]);
 
-            VegetationLibraryRecord vegetation = new VegetationLibraryRecord(vegetationIndex, architectural_resistance,
-                    min_stomatal_resistanc, laiMonths, albedoMonths, roughMonths, displMonths, wind_height, wind_atten, rgl,
-                    rad_atten, trunk_ratio);
+            VegetationLibraryRecord vegetation = new VegetationLibraryRecord(vegetationIndex, architecturalResistance,
+                    minStomatalResistanc, laiMonths, albedoMonths, roughMonths, displMonths, windHeight, windAtten, rgl,
+                    radAtten, trunkRatio);
 
             data.put(vegetationIndex, vegetation);
         }

--- a/jgrassgears/src/main/java/org/jgrasstools/gears/modules/v/marchingsquares/OmsMarchingSquaresVectorializer.java
+++ b/jgrassgears/src/main/java/org/jgrasstools/gears/modules/v/marchingsquares/OmsMarchingSquaresVectorializer.java
@@ -28,11 +28,11 @@ import static org.jgrasstools.gears.i18n.GearsMessages.OMSMARCHINGSQUARESVECTORI
 import static org.jgrasstools.gears.i18n.GearsMessages.OMSMARCHINGSQUARESVECTORIALIZER_NAME;
 import static org.jgrasstools.gears.i18n.GearsMessages.OMSMARCHINGSQUARESVECTORIALIZER_STATUS;
 import static org.jgrasstools.gears.i18n.GearsMessages.OMSMARCHINGSQUARESVECTORIALIZER_UI;
-import static org.jgrasstools.gears.i18n.GearsMessages.OMSMARCHINGSQUARESVECTORIALIZER_defaultFeatureField_DESCRIPTION;
-import static org.jgrasstools.gears.i18n.GearsMessages.OMSMARCHINGSQUARESVECTORIALIZER_inGeodata_DESCRIPTION;
-import static org.jgrasstools.gears.i18n.GearsMessages.OMSMARCHINGSQUARESVECTORIALIZER_outGeodata_DESCRIPTION;
-import static org.jgrasstools.gears.i18n.GearsMessages.OMSMARCHINGSQUARESVECTORIALIZER_pThres_DESCRIPTION;
-import static org.jgrasstools.gears.i18n.GearsMessages.OMSMARCHINGSQUARESVECTORIALIZER_pValue_DESCRIPTION;
+import static org.jgrasstools.gears.i18n.GearsMessages.OMSMARCHINGSQUARESVECTORIALIZER_DEFAULT_FEATURE_FIELD_DESCRIPTION;
+import static org.jgrasstools.gears.i18n.GearsMessages.OMSMARCHINGSQUARESVECTORIALIZER_IN_GEODATA_DESCRIPTION;
+import static org.jgrasstools.gears.i18n.GearsMessages.OMSMARCHINGSQUARESVECTORIALIZER_OUT_GEODATA_DESCRIPTION;
+import static org.jgrasstools.gears.i18n.GearsMessages.OMSMARCHINGSQUARESVECTORIALIZER_P_THRES_DESCRIPTION;
+import static org.jgrasstools.gears.i18n.GearsMessages.OMSMARCHINGSQUARESVECTORIALIZER_P_VALUE_DESCRIPTION;
 import static org.jgrasstools.gears.libs.modules.JGTConstants.doubleNovalue;
 import static org.jgrasstools.gears.libs.modules.JGTConstants.isNovalue;
 import static org.jgrasstools.gears.utils.coverage.CoverageUtilities.COLS;
@@ -93,23 +93,23 @@ import com.vividsolutions.jts.geom.Polygon;
 @UI(OMSMARCHINGSQUARESVECTORIALIZER_UI)
 public class OmsMarchingSquaresVectorializer extends JGTModel {
 
-    @Description(OMSMARCHINGSQUARESVECTORIALIZER_inGeodata_DESCRIPTION)
+    @Description(OMSMARCHINGSQUARESVECTORIALIZER_IN_GEODATA_DESCRIPTION)
     @In
     public GridCoverage2D inGeodata;
 
-    @Description(OMSMARCHINGSQUARESVECTORIALIZER_pValue_DESCRIPTION)
+    @Description(OMSMARCHINGSQUARESVECTORIALIZER_P_VALUE_DESCRIPTION)
     @In
     public Double pValue = doubleNovalue;
 
-    @Description(OMSMARCHINGSQUARESVECTORIALIZER_defaultFeatureField_DESCRIPTION)
+    @Description(OMSMARCHINGSQUARESVECTORIALIZER_DEFAULT_FEATURE_FIELD_DESCRIPTION)
     @In
     public String defaultFeatureField = "value";
 
-    @Description(OMSMARCHINGSQUARESVECTORIALIZER_pThres_DESCRIPTION)
+    @Description(OMSMARCHINGSQUARESVECTORIALIZER_P_THRES_DESCRIPTION)
     @In
     public double pThres = 0;
 
-    @Description(OMSMARCHINGSQUARESVECTORIALIZER_outGeodata_DESCRIPTION)
+    @Description(OMSMARCHINGSQUARESVECTORIALIZER_OUT_GEODATA_DESCRIPTION)
     @Out
     public SimpleFeatureCollection outGeodata = null;
 

--- a/jgrassgears/src/test/java/org/jgrasstools/gears/modules/TestAdigeBoundaryConditions.java
+++ b/jgrassgears/src/test/java/org/jgrasstools/gears/modules/TestAdigeBoundaryConditions.java
@@ -2,6 +2,7 @@ package org.jgrasstools.gears.modules;
 
 import java.io.File;
 import java.util.HashMap;
+import java.util.Map;
 
 import org.jgrasstools.gears.io.adige.AdigeBoundaryCondition;
 import org.jgrasstools.gears.io.adige.AdigeBoundaryConditionReader;
@@ -18,21 +19,21 @@ public class TestAdigeBoundaryConditions extends HMTestCase {
         File tmpAbc = File.createTempFile("testadigeboundcond", ".csv");
 
         AdigeBoundaryCondition abc1 = new AdigeBoundaryCondition();
-        abc1.basinId = 1;
-        abc1.discharge = 10.0;
-        abc1.dischargeSub = 5.0;
-        abc1.S1 = 6.0;
-        abc1.S2 = 7.0;
+        abc1.setBasinId(1);
+        abc1.setDischarge(10.0);
+        abc1.setDischargeSub(5.0);
+        abc1.setS1(6.0);
+        abc1.setS2(7.0);
         AdigeBoundaryCondition abc2 = new AdigeBoundaryCondition();
-        abc2.basinId = 2;
-        abc2.discharge = 20.0;
-        abc2.dischargeSub = 10.0;
-        abc2.S1 = 12.0;
-        abc2.S2 = 14.0;
+        abc2.setBasinId(2);
+        abc2.setDischarge(20.0);
+        abc2.setDischargeSub(10.0);
+        abc2.setS1(12.0);
+        abc2.setS2(14.0);
 
         HashMap<Integer, AdigeBoundaryCondition> condList = new HashMap<Integer, AdigeBoundaryCondition>();
-        condList.put(abc1.basinId, abc1);
-        condList.put(abc2.basinId, abc2);
+        condList.put(abc1.getBasinId(), abc1);
+        condList.put(abc2.getBasinId(), abc2);
 
         AdigeBoundaryConditionWriter writer = new AdigeBoundaryConditionWriter();
         writer.file = tmpAbc.getAbsolutePath();
@@ -44,17 +45,17 @@ public class TestAdigeBoundaryConditions extends HMTestCase {
         AdigeBoundaryConditionReader reader = new AdigeBoundaryConditionReader();
         reader.file = tmpAbc.getAbsolutePath();
         reader.read();
-        HashMap<Integer, AdigeBoundaryCondition> data = reader.data;
+        Map<Integer, AdigeBoundaryCondition> data = reader.data;
 
         AdigeBoundaryCondition readAbc1 = data.get(1);
-        assertEquals(1, readAbc1.basinId);
-        assertEquals(10.0, readAbc1.discharge);
-        assertEquals(5.0, readAbc1.dischargeSub);
+        assertEquals(1, readAbc1.getBasinId());
+        assertEquals(10.0, readAbc1.getDischarge());
+        assertEquals(5.0, readAbc1.getDischargeSub());
 
         AdigeBoundaryCondition readAbc2 = data.get(2);
-        assertEquals(2, readAbc2.basinId);
-        assertEquals(20.0, readAbc2.discharge);
-        assertEquals(10.0, readAbc2.dischargeSub);
+        assertEquals(2, readAbc2.getBasinId());
+        assertEquals(20.0, readAbc2.getDischarge());
+        assertEquals(10.0, readAbc2.getDischargeSub());
 
         reader.close();
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S00115 - Constant names should comply with a naming convention.
squid:ClassVariableVisibilityCheck - Class variable fields should not have public accessibility.
squid:S1319 - Declarations should use Java collection interfaces such as "List" rather than specific implementation classes such as "LinkedList".
squid:S00117 - Local variable and method parameter names should comply with a naming convention.
squid:S00116 - Field names should comply with a naming convention.
squid:S2293 - The diamond operator ("<>") should be used.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S00115
https://dev.eclipse.org/sonar/rules/show/squid:ClassVariableVisibilityCheck
https://dev.eclipse.org/sonar/rules/show/squid:S1319
https://dev.eclipse.org/sonar/rules/show/squid:S00117
https://dev.eclipse.org/sonar/rules/show/squid:S00116
https://dev.eclipse.org/sonar/rules/show/squid:S2293
Please let me know if you have any questions.
George Kankava