### PR TITLE
multiple code improvements: squid:S1192, squid:S1488, squid:S1319, squid:S2293, squid:S1157, squid:S1155, squid:LowerCaseLongSuffixCheck, squid:CommentedOutCodeLine

### DIFF
--- a/jgrassgears/src/main/java/org/jgrasstools/gears/io/converters/IdValuesArray2IdValuesConverter.java
+++ b/jgrassgears/src/main/java/org/jgrasstools/gears/io/converters/IdValuesArray2IdValuesConverter.java
@@ -32,6 +32,7 @@ import static org.jgrasstools.gears.libs.modules.JGTConstants.isNovalue;
 
 import java.io.IOException;
 import java.util.HashMap;
+import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 
@@ -62,16 +63,16 @@ public class IdValuesArray2IdValuesConverter extends JGTModel {
 
     @Description(IDVALUESARRAY2IDVALUESCONVERTER_IN_DATA_DESCRIPTION)
     @In
-    public HashMap<Integer, double[]> inData;
+    public Map<Integer, double[]> inData;
 
     @Description(IDVALUESARRAY2IDVALUESCONVERTER_OUT_DATA_DESCRIPTION)
     @Out
-    public HashMap<Integer, Double> outData;
+    public Map<Integer, Double> outData;
 
     @Execute
     public void convert() throws IOException {
         if (outData == null) {
-            outData = new HashMap<Integer, Double>();
+            outData = new HashMap<>();
         }
         Set<Entry<Integer, double[]>> entries = inData.entrySet();
         for( Entry<Integer, double[]> entry : entries ) {

--- a/jgrassgears/src/main/java/org/jgrasstools/gears/io/csv/OmsCsvMatrixReader.java
+++ b/jgrassgears/src/main/java/org/jgrasstools/gears/io/csv/OmsCsvMatrixReader.java
@@ -124,12 +124,12 @@ public class OmsCsvMatrixReader extends JGTModel {
 
     private int columnCount;
 
-    private List<String> outIdsList = new ArrayList<String>();
-    private List<String> outLabelsList = new ArrayList<String>();
-    private List<String> outFormatsList = new ArrayList<String>();
-    private List<String> outTypesList = new ArrayList<String>();
+    private List<String> outIdsList = new ArrayList<>();
+    private List<String> outLabelsList = new ArrayList<>();
+    private List<String> outFormatsList = new ArrayList<>();
+    private List<String> outTypesList = new ArrayList<>();
 
-    private List<double[]> outDataList = new ArrayList<double[]>();
+    private List<double[]> outDataList = new ArrayList<>();
 
     private DateTimeFormatter dateFormatter;
 
@@ -143,7 +143,7 @@ public class OmsCsvMatrixReader extends JGTModel {
             for( Entry<String, String> entry : entrySet ) {
                 String key = entry.getKey();
                 String value = entry.getValue();
-                if (key.toLowerCase().equals("subtitle")) {
+                if ("subtitle".equalsIgnoreCase(key)) {
                     outSubTitle = value;
                 }
             }
@@ -161,13 +161,13 @@ public class OmsCsvMatrixReader extends JGTModel {
                     String key = entry.getKey();
                     String value = entry.getValue();
 
-                    if (key.toLowerCase().equals("label")) {
+                    if ("label".equalsIgnoreCase(key)) {
                         outLabelsList.add(value);
                     }
-                    if (key.toLowerCase().equals("format")) {
+                    if ("format".equalsIgnoreCase(key)) {
                         outFormatsList.add(value);
                     }
-                    if (key.toLowerCase().equals("type")) {
+                    if ("type".equalsIgnoreCase(key)) {
                         value = value.toLowerCase().trim();
                         if (value.length() == 0) {
                             value = "double";
@@ -177,17 +177,17 @@ public class OmsCsvMatrixReader extends JGTModel {
                 }
             }
 
-            if (outIdsList.size() > 0) {
+            if (!outIdsList.isEmpty()) {
                 outIds = outIdsList.toArray(new String[0]);
             }
-            if (outLabelsList.size() > 0) {
+            if (!outLabelsList.isEmpty()) {
                 outLabels = outLabelsList.toArray(new String[0]);
             }
-            if (outFormatsList.size() > 0) {
+            if (!outFormatsList.isEmpty()) {
                 outFormats = outFormatsList.toArray(new String[0]);
             }
 
-            if (outTypesList.size() == 0) {
+            if (outTypesList.isEmpty()) {
                 for( int i = 1; i <= columnCount; i++ ) {
                     outTypesList.add("double");
                 }

--- a/jgrassgears/src/main/java/org/jgrasstools/gears/io/dbf/OmsDbfTableReader.java
+++ b/jgrassgears/src/main/java/org/jgrasstools/gears/io/dbf/OmsDbfTableReader.java
@@ -34,6 +34,7 @@ import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import oms3.annotations.Author;
 import oms3.annotations.Description;
@@ -68,7 +69,7 @@ public class OmsDbfTableReader extends JGTModel {
 
     @Description(OMSDBFTABLEREADER_OUT_TABLE_DATA_DESCRIPTION)
     @Out
-    public HashMap<String, List<Object>> outTabledata = null;
+    public Map<String, List<Object>> outTabledata = null;
 
     @Execute
     public void readTable() throws IOException {
@@ -84,7 +85,7 @@ public class OmsDbfTableReader extends JGTModel {
             dbfReader = new DbaseFileReader(fis.getChannel(), false, Charset.defaultCharset());
             final DbaseFileHeader header = dbfReader.getHeader();
             int numFields = header.getNumFields();
-            outTabledata = new HashMap<String, List<Object>>();
+            outTabledata = new HashMap<>();
             for( int i = 0; i < numFields; i++ ) {
                 String fieldName = header.getFieldName(i);
                 outTabledata.put(fieldName, new ArrayList<Object>());
@@ -116,7 +117,7 @@ public class OmsDbfTableReader extends JGTModel {
      * @return the read table.
      * @throws IOException
      */
-    public static HashMap<String, List<Object>> readDbf( String path ) throws IOException {
+    public static Map<String, List<Object>> readDbf( String path ) throws IOException {
 
         OmsDbfTableReader reader = new OmsDbfTableReader();
         reader.file = path;

--- a/jgrassgears/src/main/java/org/jgrasstools/gears/io/disktree/DiskTreeReader.java
+++ b/jgrassgears/src/main/java/org/jgrasstools/gears/io/disktree/DiskTreeReader.java
@@ -61,7 +61,7 @@ public class DiskTreeReader implements IDiskTree {
         File file = new File(path);
         raf = new RandomAccessFile(file, "r");
 
-        raf.seek(6l);
+        raf.seek(6L);
         checkVersions();
 
         long position = INDEX_ADDRESS_POSITION;
@@ -110,8 +110,7 @@ public class DiskTreeReader implements IDiskTree {
         raf.read(geomBytes);
 
         ObjectInputStream in = new ObjectInputStream(new ByteArrayInputStream(geomBytes));
-        Geometry geometry = (Geometry) in.readObject();
-        return geometry;
+        return (Geometry) in.readObject();
     }
 
     /**
@@ -122,22 +121,4 @@ public class DiskTreeReader implements IDiskTree {
     public void close() throws IOException {
         raf.close();
     }
-
-    // public static void main( String[] args ) throws Exception {
-    //
-    //
-    // DiskTreeReader writer = new DiskTreeReader("/home/moovida/TMP/index.bin");
-    // Quadtree indexObj = writer.readIndex();
-    //
-    // List queryAll = indexObj.queryAll();
-    //
-    // for( Object object : queryAll ) {
-    // if (object instanceof long[]) {
-    // long[] posSize = (long[]) object;
-    // Geometry geom = writer.pickGeometry(posSize[0], posSize[1]);
-    // System.out.println(geom.toText());
-    // }
-    // }
-    //
-    // }
 }

--- a/jgrassgears/src/main/java/org/jgrasstools/gears/io/disktree/DiskTreeWriter.java
+++ b/jgrassgears/src/main/java/org/jgrasstools/gears/io/disktree/DiskTreeWriter.java
@@ -128,22 +128,6 @@ public class DiskTreeWriter implements IDiskTree {
         ObjectOutputStream out = new ObjectOutputStream(bos);
         out.writeObject(obj);
         out.close();
-        byte[] treeBytes = bos.toByteArray();
-        return treeBytes;
+        return bos.toByteArray();
     }
-
-    // public static void main( String[] args ) throws ParseException, IOException {
-    //
-    // WKTReader r = new WKTReader();
-    // Geometry pol = r.read("POLYGON ((210 350, 230 310, 290 350, 290 350, 210 350))");
-    // pol.setUserData(1);
-    // Geometry line = r.read("LINESTRING (50 380, 90 210, 180 160, 240 40, 240 40)");
-    // line.setUserData(2);
-    // Geometry point = r.read("POINT (130 120)");
-    // point.setUserData(3);
-    //
-    // DiskTreeWriter writer = new DiskTreeWriter("/home/moovida/TMP/index.bin");
-    // writer.writeGeometries(new Geometry[]{pol, line, point});
-    //
-    // }
 }

--- a/jgrassgears/src/main/java/org/jgrasstools/gears/io/dxfdwg/libs/GeometryTranslator.java
+++ b/jgrassgears/src/main/java/org/jgrasstools/gears/io/dxfdwg/libs/GeometryTranslator.java
@@ -49,6 +49,8 @@ import com.vividsolutions.jts.geom.Point;
 import com.vividsolutions.jts.geom.Polygon;
 
 public class GeometryTranslator {
+    private static final String LAYER = "layer";
+    private static final String THE_GEOM = "the_geom";
     private static GeometryFactory gF = new GeometryFactory();
     private final CoordinateReferenceSystem crs;
     public GeometryTranslator( CoordinateReferenceSystem crs ) {
@@ -97,16 +99,15 @@ public class GeometryTranslator {
         SimpleFeatureTypeBuilder b = new SimpleFeatureTypeBuilder();
         b.setName(typeName);
         b.setCRS(crs);
-        b.add("the_geom", Point.class);
+        b.add(THE_GEOM, Point.class);
         b.add("text", String.class);
-        b.add("layer", String.class);
+        b.add(LAYER, String.class);
         SimpleFeatureType type = b.buildFeatureType();
         SimpleFeatureBuilder builder = new SimpleFeatureBuilder(type);
         Geometry point = gF.createPoint(coord);
         Object[] values = new Object[]{point, textString, layerName};
         builder.addAll(values);
-        SimpleFeature feature = builder.buildFeature(typeName + "." + id);
-        return feature;
+        return builder.buildFeature(typeName + "." + id);
     }
 
     /**
@@ -128,15 +129,14 @@ public class GeometryTranslator {
             SimpleFeatureTypeBuilder b = new SimpleFeatureTypeBuilder();
             b.setName(typeName);
             b.setCRS(crs);
-            b.add("the_geom", LineString.class);
-            b.add("layer", String.class);
+            b.add(THE_GEOM, LineString.class);
+            b.add(LAYER, String.class);
             SimpleFeatureType type = b.buildFeatureType();
             SimpleFeatureBuilder builder = new SimpleFeatureBuilder(type);
             Geometry lineString = gF.createLineString(coordList.toCoordinateArray());
             Object[] values = new Object[]{lineString, layerName};
             builder.addAll(values);
-            SimpleFeature feature = builder.buildFeature(typeName + "." + id);
-            return feature;
+            return builder.buildFeature(typeName + "." + id);
         }
         return null;
     }
@@ -158,15 +158,14 @@ public class GeometryTranslator {
             SimpleFeatureTypeBuilder b = new SimpleFeatureTypeBuilder();
             b.setName(typeName);
             b.setCRS(crs);
-            b.add("the_geom", LineString.class);
-            b.add("layer", String.class);
+            b.add(THE_GEOM, LineString.class);
+            b.add(LAYER, String.class);
             SimpleFeatureType type = b.buildFeatureType();
             SimpleFeatureBuilder builder = new SimpleFeatureBuilder(type);
             Geometry lineString = gF.createLineString(coordList.toCoordinateArray());
             Object[] values = new Object[]{lineString, layerName};
             builder.addAll(values);
-            SimpleFeature feature = builder.buildFeature(typeName + "." + id);
-            return feature;
+            return builder.buildFeature(typeName + "." + id);
         }
         return null;
     }
@@ -188,15 +187,14 @@ public class GeometryTranslator {
             SimpleFeatureTypeBuilder b = new SimpleFeatureTypeBuilder();
             b.setName(typeName);
             b.setCRS(crs);
-            b.add("the_geom", LineString.class);
-            b.add("layer", String.class);
+            b.add(THE_GEOM, LineString.class);
+            b.add(LAYER, String.class);
             SimpleFeatureType type = b.buildFeatureType();
             SimpleFeatureBuilder builder = new SimpleFeatureBuilder(type);
             Geometry lineString = gF.createLineString(coordList.toCoordinateArray());
             Object[] values = new Object[]{lineString, layerName};
             builder.addAll(values);
-            SimpleFeature feature = builder.buildFeature(typeName + "." + id);
-            return feature;
+            return builder.buildFeature(typeName + "." + id);
         }
         return null;
     }
@@ -215,15 +213,14 @@ public class GeometryTranslator {
         SimpleFeatureTypeBuilder b = new SimpleFeatureTypeBuilder();
         b.setName(typeName);
         b.setCRS(crs);
-        b.add("the_geom", MultiPoint.class);
-        b.add("layer", String.class);
+        b.add(THE_GEOM, MultiPoint.class);
+        b.add(LAYER, String.class);
         SimpleFeatureType type = b.buildFeatureType();
         SimpleFeatureBuilder builder = new SimpleFeatureBuilder(type);
         Geometry points = gF.createMultiPoint(coordList.toCoordinateArray());
         Object[] values = new Object[]{points, layerName};
         builder.addAll(values);
-        SimpleFeature feature = builder.buildFeature(typeName + "." + id);
-        return feature;
+        return builder.buildFeature(typeName + "." + id);
     }
 
     /**
@@ -244,15 +241,14 @@ public class GeometryTranslator {
         SimpleFeatureTypeBuilder b = new SimpleFeatureTypeBuilder();
         b.setName(typeName);
         b.setCRS(crs);
-        b.add("the_geom", LineString.class);
-        b.add("layer", String.class);
+        b.add(THE_GEOM, LineString.class);
+        b.add(LAYER, String.class);
         SimpleFeatureType type = b.buildFeatureType();
         SimpleFeatureBuilder builder = new SimpleFeatureBuilder(type);
         Geometry lineString = gF.createLineString(coordList.toCoordinateArray());
         Object[] values = new Object[]{lineString, layerName};
         builder.addAll(values);
-        SimpleFeature feature = builder.buildFeature(typeName + "." + id);
-        return feature;
+        return builder.buildFeature(typeName + "." + id);
     }
 
     /**
@@ -280,16 +276,15 @@ public class GeometryTranslator {
         SimpleFeatureTypeBuilder b = new SimpleFeatureTypeBuilder();
         b.setName(typeName);
         b.setCRS(crs);
-        b.add("the_geom", Polygon.class);
-        b.add("layer", String.class);
+        b.add(THE_GEOM, Polygon.class);
+        b.add(LAYER, String.class);
         SimpleFeatureType type = b.buildFeatureType();
         SimpleFeatureBuilder builder = new SimpleFeatureBuilder(type);
         LinearRing linearRing = gF.createLinearRing(coordList.toCoordinateArray());
         Geometry polygon = gF.createPolygon(linearRing, null);
         Object[] values = new Object[]{polygon, layerName};
         builder.addAll(values);
-        SimpleFeature feature = builder.buildFeature(typeName + "." + id);
-        return feature;
+        return builder.buildFeature(typeName + "." + id);
     }
 
     /**
@@ -314,16 +309,15 @@ public class GeometryTranslator {
         SimpleFeatureTypeBuilder b = new SimpleFeatureTypeBuilder();
         b.setName(typeName);
         b.setCRS(crs);
-        b.add("the_geom", Polygon.class);
-        b.add("layer", String.class);
+        b.add(THE_GEOM, Polygon.class);
+        b.add(LAYER, String.class);
         SimpleFeatureType type = b.buildFeatureType();
         SimpleFeatureBuilder builder = new SimpleFeatureBuilder(type);
         LinearRing linearRing = gF.createLinearRing(coordList.toCoordinateArray());
         Geometry polygon = gF.createPolygon(linearRing, null);
         Object[] values = new Object[]{polygon, layerName};
         builder.addAll(values);
-        SimpleFeature feature = builder.buildFeature(typeName + "." + id);
-        return feature;
+        return builder.buildFeature(typeName + "." + id);
     }
 
     /**
@@ -346,14 +340,13 @@ public class GeometryTranslator {
         SimpleFeatureTypeBuilder b = new SimpleFeatureTypeBuilder();
         b.setName(typeName);
         b.setCRS(crs);
-        b.add("the_geom", LineString.class);
-        b.add("layer", String.class);
+        b.add(THE_GEOM, LineString.class);
+        b.add(LAYER, String.class);
         SimpleFeatureType type = b.buildFeatureType();
         SimpleFeatureBuilder builder = new SimpleFeatureBuilder(type);
         Geometry lineString = gF.createLineString(coordList.toCoordinateArray());
         Object[] values = new Object[]{lineString, layerName};
         builder.addAll(values);
-        SimpleFeature feature = builder.buildFeature(typeName + "." + id);
-        return feature;
+        return builder.buildFeature(typeName + "." + id);
     }
 }

--- a/jgrassgears/src/test/java/org/jgrasstools/gears/modules/TestId2ValueConverters.java
+++ b/jgrassgears/src/test/java/org/jgrasstools/gears/modules/TestId2ValueConverters.java
@@ -1,6 +1,7 @@
 package org.jgrasstools.gears.modules;
 
 import java.util.HashMap;
+import java.util.Map;
 
 import org.jgrasstools.gears.io.converters.IdValuesArray2IdValuesConverter;
 import org.jgrasstools.gears.utils.HMTestCase;
@@ -25,7 +26,7 @@ public class TestId2ValueConverters extends HMTestCase {
         IdValuesArray2IdValuesConverter converter = new IdValuesArray2IdValuesConverter();
         converter.inData = data;
         converter.convert();
-        HashMap<Integer, Double> outData = converter.outData;
+        Map<Integer, Double> outData = converter.outData;
 
         Double c1 = outData.get(1);
         Double c2 = outData.get(2);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S1192 - String literals should not be duplicated.
squid:S1488 - Local Variables should not be declared and then immediately returned or thrown.
squid:S1319 - Declarations should use Java collection interfaces such as "List" rather than specific implementation classes such as "LinkedList".
squid:S2293 - The diamond operator ("<>") should be used.
squid:S1157 - Case insensitive string comparisons should be made without intermediate upper or lower casing.
squid:S1155 - Collection.isEmpty() should be used to test for emptiness.
squid:LowerCaseLongSuffixCheck - Long suffix "L" should be upper case.
squid:CommentedOutCodeLine - Sections of code should not be "commented out".
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1192
https://dev.eclipse.org/sonar/rules/show/squid:S1488
https://dev.eclipse.org/sonar/rules/show/squid:S1319
https://dev.eclipse.org/sonar/rules/show/squid:S2293
https://dev.eclipse.org/sonar/rules/show/squid:S1157
https://dev.eclipse.org/sonar/rules/show/squid:S1155
https://dev.eclipse.org/sonar/rules/show/squid:LowerCaseLongSuffixCheck
https://dev.eclipse.org/sonar/rules/show/squid:CommentedOutCodeLine
Please let me know if you have any questions.
George Kankava