### PR TITLE
multiple code improvements: squid:S1149, squid:S1192, squid:S1118, squid:S1444, squid:S1488, squid:CommentedOutCodeLine, squid:S1854, squid:S1155, squid:S1319, squid:UselessParenthesesCheck, squid:S2293

### DIFF
--- a/jgrassgears/src/main/java/org/jgrasstools/gears/io/dxfdwg/libs/DwgHandler.java
+++ b/jgrassgears/src/main/java/org/jgrasstools/gears/io/dxfdwg/libs/DwgHandler.java
@@ -36,8 +36,7 @@ public class DwgHandler {
     }
 
     public DwgReader getDwgReader() throws Exception {
-        DwgReader dwgReader = new DwgReader(dwgFile, gTranslator);
-        return dwgReader;
+        return new DwgReader(dwgFile, gTranslator);
     }
 
     public List<String> getLayerTypes() throws Exception {
@@ -49,7 +48,7 @@ public class DwgHandler {
         dwgFile.blockManagement();
 
         List<String> layerNames = dwgFile.getLayerNames();
-        if (layerNames.size() < 1) {
+        if (layerNames.isEmpty()) {
             throw new IOException("No layer found in the file.");
         }
 

--- a/jgrassgears/src/main/java/org/jgrasstools/gears/io/dxfdwg/libs/DwgReader.java
+++ b/jgrassgears/src/main/java/org/jgrasstools/gears/io/dxfdwg/libs/DwgReader.java
@@ -20,6 +20,7 @@ package org.jgrasstools.gears.io.dxfdwg.libs;
 
 import java.io.IOException;
 import java.util.HashMap;
+import java.util.Map;
 import java.util.Vector;
 
 import org.geotools.data.simple.SimpleFeatureCollection;
@@ -57,6 +58,8 @@ public class DwgReader {
     FeatureIterator<SimpleFeature> enumeration;
     int chosenLayerType = -1;
 
+    private static final String LINES = "lines";
+
     // different feature types
     private DefaultFeatureCollection contourFeatures = new DefaultFeatureCollection();
     private DefaultFeatureCollection multiLineFeatures = new DefaultFeatureCollection();
@@ -86,7 +89,7 @@ public class DwgReader {
             String layerName = pFile.getLayerName(entity);
             if (entity instanceof DwgArc) {
                 DwgArc arc = (DwgArc) entity;
-                SimpleFeature feature = gTranslator.convertDwgArc("lines", layerName, arc, cat);
+                SimpleFeature feature = gTranslator.convertDwgArc(LINES, layerName, arc, cat);
                 multiLineFeatures.add(feature);
             } else if (entity instanceof DwgCircle) {
                 DwgCircle circle = (DwgCircle) entity;
@@ -94,7 +97,7 @@ public class DwgReader {
                 multiPolygonFeatures.add(feature);
             } else if (entity instanceof DwgLine) {
                 DwgLine line = (DwgLine) entity;
-                SimpleFeature feature = gTranslator.convertDwgLine("lines", layerName, line, cat);
+                SimpleFeature feature = gTranslator.convertDwgLine(LINES, layerName, line, cat);
                 multiLineFeatures.add(feature);
             } else if (entity instanceof DwgPoint) {
                 DwgPoint point = (DwgPoint) entity;
@@ -102,25 +105,24 @@ public class DwgReader {
                 multiPointFeatures.add(feature);
             } else if (entity instanceof DwgPolyline2D) {
                 DwgPolyline2D polyline2d = (DwgPolyline2D) entity;
-                SimpleFeature feature = gTranslator.convertDwgPolyline2D("lines", layerName, polyline2d, cat);
+                SimpleFeature feature = gTranslator.convertDwgPolyline2D(LINES, layerName, polyline2d, cat);
                 if (feature != null)
                     multiLineFeatures.add(feature);
             } else if (entity instanceof DwgPolyline3D) {
                 DwgPolyline3D polyline3d = (DwgPolyline3D) entity;
-                SimpleFeature feature = gTranslator.convertDwgPolyline3D("lines", layerName, polyline3d, cat);
+                SimpleFeature feature = gTranslator.convertDwgPolyline3D(LINES, layerName, polyline3d, cat);
                 if (feature != null)
                     multiLineFeatures.add(feature);
-                // contourFeatures.add(f);
             } else if (entity instanceof DwgText) {
-                DwgText text = ((DwgText) entity);
+                DwgText text = (DwgText) entity;
                 SimpleFeature feature = gTranslator.convertDwgText("text", layerName, text, cat);
                 textFeatures.add(feature);
             } else if (entity instanceof DwgAttrib) {
-                DwgAttrib attribute = ((DwgAttrib) entity);
+                DwgAttrib attribute = (DwgAttrib) entity;
                 SimpleFeature feature = gTranslator.convertDwgAttribute("text", layerName, attribute, cat);
                 attributesFeatures.add(feature);
             } else if (entity instanceof DwgMText) {
-                DwgMText text = ((DwgMText) entity);
+                DwgMText text = (DwgMText) entity;
                 SimpleFeature feature = gTranslator.convertDwgMText("text", layerName, text, cat);
                 textFeatures.add(feature);
             } else if (entity instanceof DwgSolid) {
@@ -129,7 +131,7 @@ public class DwgReader {
                 multiPolygonFeatures.add(feature);
             } else if (entity instanceof DwgLwPolyline) {
                 DwgLwPolyline lwPolyline = (DwgLwPolyline) entity;
-                SimpleFeature feature = gTranslator.convertDwgLwPolyline("lines", layerName, lwPolyline, cat);
+                SimpleFeature feature = gTranslator.convertDwgLwPolyline(LINES, layerName, lwPolyline, cat);
                 multiLineFeatures.add(feature);
             }
             cat++;
@@ -137,24 +139,24 @@ public class DwgReader {
         }
     }
 
-    public HashMap<String, SimpleFeatureCollection> getFeatureCollectionsMap() throws IOException {
-        HashMap<String, SimpleFeatureCollection> map = new HashMap<String, SimpleFeatureCollection>();
-        if (textFeatures.size() > 0) {
+    public Map<String, SimpleFeatureCollection> getFeatureCollectionsMap() throws IOException {
+        Map<String, SimpleFeatureCollection> map = new HashMap<>();
+        if (!textFeatures.isEmpty()) {
             map.put("text", textFeatures);
         }
-        if (attributesFeatures.size() > 0) {
+        if (!attributesFeatures.isEmpty()) {
             map.put("text", attributesFeatures);
         }
-        if (multiLineFeatures.size() > 0) {
-            map.put("lines", multiLineFeatures);
+        if (!multiLineFeatures.isEmpty()) {
+            map.put(LINES, multiLineFeatures);
         }
-        if (contourFeatures.size() > 0) {
-            map.put("lines", contourFeatures);
+        if (!contourFeatures.isEmpty()) {
+            map.put(LINES, contourFeatures);
         }
-        if (multiPointFeatures.size() > 0) {
+        if (!multiPointFeatures.isEmpty()) {
             map.put("points", multiPointFeatures);
         }
-        if (multiPolygonFeatures.size() > 0) {
+        if (!multiPolygonFeatures.isEmpty()) {
             map.put("polygons", multiPolygonFeatures);
         }
         return map;
@@ -185,7 +187,6 @@ public class DwgReader {
 
     public synchronized void close() throws IOException {
         if (file != null) {
-            // file.close();
             file = null;
         }
         enumeration = null;

--- a/jgrassgears/src/main/java/org/jgrasstools/gears/io/dxfdwg/libs/DxfUtils.java
+++ b/jgrassgears/src/main/java/org/jgrasstools/gears/io/dxfdwg/libs/DxfUtils.java
@@ -57,7 +57,9 @@ public class DxfUtils {
     public static final String TEXT_HEIGHT = "TEXT_HEIGHT";
     public static final String TEXT = "TEXT";
 
-    public static int precision = 3;
+    public static final int precision = 3;
+
+    private DxfUtils() {}
 
     /**
      * Write a {@link SimpleFeature} to dxf string.
@@ -82,7 +84,7 @@ public class DxfUtils {
         } else if (geometryType == GeometryType.POLYGON || geometryType == GeometryType.MULTIPOLYGON) {
             return polygon2Dxf(featureMate, layerName, elevationAttrName, suffix);
         } else if (g instanceof GeometryCollection) {
-            StringBuffer sb = new StringBuffer();
+            StringBuilder sb = new StringBuilder();
             for( int i = 0; i < g.getNumGeometries(); i++ ) {
                 SimpleFeature ff = SimpleFeatureBuilder.copy(featureMate.getFeature());
                 ff.setDefaultGeometry(g.getGeometryN(i));
@@ -97,16 +99,16 @@ public class DxfUtils {
 
     private static String point2Dxf( FeatureMate featureMate, String layerName, String elevationAttrName ) {
 
-        StringBuffer sb = null;
+        StringBuilder sb;
 
         // TEXT
         SimpleFeature feature = featureMate.getFeature();
         Object attribute = FeatureUtilities.getAttributeCaseChecked(feature, TEXT);
-        boolean hasText = (attribute != null && !attribute.equals(""));
+        boolean hasText = attribute != null && !attribute.equals("");
         if (hasText) {
-            sb = new StringBuffer(DxfGroup.toString(0, TEXT));
+            sb = new StringBuilder(DxfGroup.toString(0, TEXT));
         } else {
-            sb = new StringBuffer(DxfGroup.toString(0, POINT));
+            sb = new StringBuilder(DxfGroup.toString(0, POINT));
         }
 
         // LAYER
@@ -148,13 +150,13 @@ public class DxfUtils {
         // Correction added by L. Becker and R Littlefield on 2006-11-08
         // It writes 2 points-only polylines in a line instead of a polyline
         // to make it possible to incorporate big dataset in View32
-        boolean is2CoordsLine = (coords.length == 2);
+        boolean is2CoordsLine = coords.length == 2;
         boolean doLine = is2CoordsLine && force2CoordsToLine;
-        StringBuffer sb;
+        StringBuilder sb;
         if (doLine) {
-            sb = new StringBuffer(DxfGroup.toString(0, LINE));
+            sb = new StringBuilder(DxfGroup.toString(0, LINE));
         } else {
-            sb = new StringBuffer(DxfGroup.toString(0, POLYLINE));
+            sb = new StringBuilder(DxfGroup.toString(0, POLYLINE));
         }
 
         double elev = Double.NaN;
@@ -211,7 +213,7 @@ public class DxfUtils {
     private static String polygon2Dxf( FeatureMate featureMate, String layerName, String elevationAttrName, boolean suffix ) {
         Geometry geometry = featureMate.getGeometry();
         int numGeometries = geometry.getNumGeometries();
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
         for( int g = 0; g < numGeometries; g++ ) {
             Polygon geom = (Polygon) geometry.getGeometryN(g);
 
@@ -252,7 +254,6 @@ public class DxfUtils {
             }
             sb.append(DxfGroup.toString(0, SEQEND));
             for( int h = 0; h < geom.getNumInteriorRing(); h++ ) {
-                // System.out.println("polygon2Dxf (hole)" + suffix);
                 sb.append(DxfGroup.toString(0, POLYLINE));
                 if (suffix)
                     sb.append(DxfGroup.toString(8, layerName + SUFFIX));
@@ -290,7 +291,7 @@ public class DxfUtils {
         return sb.toString();
     }
 
-    private static void handleLAYER( SimpleFeature feature, String layerName, StringBuffer sb ) {
+    private static void handleLAYER( SimpleFeature feature, String layerName, StringBuilder sb ) {
         Object attribute;
         attribute = FeatureUtilities.getAttributeCaseChecked(feature, LAYER);
         if (attribute != null && !attribute.equals("")) {
@@ -300,7 +301,7 @@ public class DxfUtils {
         }
     }
 
-    private static void handleTEXTHEIGHT( SimpleFeature feature, StringBuffer sb, boolean hasText ) {
+    private static void handleTEXTHEIGHT( SimpleFeature feature, StringBuilder sb, boolean hasText ) {
         Object attribute;
         attribute = FeatureUtilities.getAttributeCaseChecked(feature, TEXT_HEIGHT);
         boolean hasTextHeight = attribute != null && !attribute.equals(new Float(0f));
@@ -313,14 +314,14 @@ public class DxfUtils {
         }
     }
 
-    private static void handleColor( SimpleFeature feature, StringBuffer sb ) {
+    private static void handleColor( SimpleFeature feature, StringBuilder sb ) {
         Object attribute = FeatureUtilities.getAttributeCaseChecked(feature, COLOR);
         if (attribute != null && ((Integer) attribute).intValue() != 256) {
             sb.append(DxfGroup.toString(62, feature.getAttribute(COLOR).toString()));
         }
     }
 
-    private static void handleTHICKNESS( SimpleFeature feature, StringBuffer sb ) {
+    private static void handleTHICKNESS( SimpleFeature feature, StringBuilder sb ) {
         Object attribute = FeatureUtilities.getAttributeCaseChecked(feature, THICKNESS);
         if (attribute != null && !attribute.equals(new Float(0f))) {
             sb.append(DxfGroup.toString(39, feature.getAttribute(THICKNESS)));
@@ -329,14 +330,14 @@ public class DxfUtils {
         }
     }
 
-    private static void handleELEVATION( SimpleFeature feature, StringBuffer sb ) {
+    private static void handleELEVATION( SimpleFeature feature, StringBuilder sb ) {
         Object attribute = FeatureUtilities.getAttributeCaseChecked(feature, ELEVATION);
         if (attribute != null && !attribute.equals(new Float(0f))) {
             sb.append(DxfGroup.toString(38, feature.getAttribute(ELEVATION)));
         }
     }
 
-    private static void handleLTYPE( SimpleFeature feature, StringBuffer sb ) {
+    private static void handleLTYPE( SimpleFeature feature, StringBuilder sb ) {
         Object attribute = FeatureUtilities.getAttributeCaseChecked(feature, LTYPE);
         if (attribute != null && !attribute.equals(BYLAYER)) {
             sb.append(DxfGroup.toString(6, feature.getAttribute(LTYPE)));


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S1149 - Synchronized classes Vector, Hashtable, Stack and StringBuffer should not be used.
squid:S1192 - String literals should not be duplicated.
squid:S1118 - Utility classes should not have public constructors.
squid:S1444 - "public static" fields should be constant.
squid:S1488 - Local Variables should not be declared and then immediately returned or thrown.
squid:CommentedOutCodeLine - Sections of code should not be "commented out".
squid:S1854 - Dead stores should be removed.
squid:S1155 - Collection.isEmpty() should be used to test for emptiness.
squid:S1319 - Declarations should use Java collection interfaces such as "List" rather than specific implementation classes such as "LinkedList".
squid:UselessParenthesesCheck - Useless parentheses around expressions should be removed to prevent any misunderstanding.
squid:S2293 - The diamond operator ("<>") should be used.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1149
https://dev.eclipse.org/sonar/rules/show/squid:S1192
https://dev.eclipse.org/sonar/rules/show/squid:S1118
https://dev.eclipse.org/sonar/rules/show/squid:S1444
https://dev.eclipse.org/sonar/rules/show/squid:S1488
https://dev.eclipse.org/sonar/rules/show/squid:CommentedOutCodeLine
https://dev.eclipse.org/sonar/rules/show/squid:S1854
https://dev.eclipse.org/sonar/rules/show/squid:S1155
https://dev.eclipse.org/sonar/rules/show/squid:S1319
https://dev.eclipse.org/sonar/rules/show/squid:UselessParenthesesCheck
https://dev.eclipse.org/sonar/rules/show/squid:S2293
Please let me know if you have any questions.
George Kankava