### PR TITLE
Fix the conversion of LAS long to Java long negative numbers

### DIFF
--- a/jgrassgears/src/main/java/org/jgrasstools/gears/io/las/core/v_1_0/LasReader.java
+++ b/jgrassgears/src/main/java/org/jgrasstools/gears/io/las/core/v_1_0/LasReader.java
@@ -403,7 +403,7 @@ public class LasReader extends ALasReader {
     private long getLong4Bytes() throws IOException {
         longBb.clear();
         fc.read(longBb);
-        long arr2long = ByteUtilities.byteArrayToLongLE(longDataArray);
+        long arr2long = longBb.getInt(0);
         return arr2long;
     }
 


### PR DESCRIPTION
The problem is on method LasReader.getLong4Bytes(), where ByteUtilities.byteArrayToLongLE is used to retrieve the actual value. This
works correctly if an 8 byte array were provided to byteArrayToLongLE
(so byteArrayToLongLE implementation is correct).

However, if you provide a 4 byte array (LAS longs are defined in this
way) it will work correctly for positive numbers, but it will produce
the wrong number for negative ones, because the negative sign is
stored as the most significant bit and will not be correctly set when
only shifted 3 bytes (instead of 7).

As LAS longs are always 4 bytes by definition, which is the same definition of Java int, it is safe to retrieve it as an it value.